### PR TITLE
Add PatchGAN discriminator option and simplify config

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -70,11 +70,8 @@ Generator:
   scaling_factor: 8            # Upscaling factor (e.g., 2×, 4×, 8×)
 
 Discriminator:
-  model_type: 'standard'      # Discriminator architecture selector
-  kernel_size: 3               # Conv kernel size for discriminator layers
-  n_channels: 64               # Base channel width
-  n_blocks: 8                  # Number of convolutional blocks [Standards: 8, PatchGAN: 3]
-  fc_size: 1024                # Fully connected layer size
+  model_type: 'standard'      # Discriminator architecture selector ['standard', 'patchgan']
+  n_blocks: 8                  # Number of convolutional blocks / layers
 
 TruncatedVGG:
   i: 5                         # Layer indices for feature extraction

--- a/model/SRGAN.py
+++ b/model/SRGAN.py
@@ -109,25 +109,24 @@ class SRGAN_model(pl.LightningModule):
         # Purpose: Build discriminator network for adversarial training.
         # ======================================================================
         discriminator_type = getattr(self.config.Discriminator, 'model_type', 'standard')
-        discriminator_layers = getattr(self.config.Discriminator, 'n_layers', None)
+        n_blocks = getattr(self.config.Discriminator, 'n_blocks', None)
+
         if discriminator_type == 'standard':
             from model.srgan_discriminator import Discriminator
-            n_blocks = self.config.Discriminator.n_blocks
-            if discriminator_layers is not None:
-                n_blocks = discriminator_layers
-            self.discriminator = Discriminator(
-                in_channels=self.config.Model.in_bands,
-                kernel_size=self.config.Discriminator.kernel_size,
-                n_channels=self.config.Discriminator.n_channels,
-                n_blocks=n_blocks,
-                fc_size=self.config.Discriminator.fc_size
-            )
+
+            discriminator_kwargs = {
+                "in_channels": self.config.Model.in_bands,
+            }
+            if n_blocks is not None:
+                discriminator_kwargs["n_blocks"] = n_blocks
+
+            self.discriminator = Discriminator(**discriminator_kwargs)
         elif discriminator_type == 'patchgan':
             from model.patchgan import PatchGANDiscriminator
-            patchgan_layers = discriminator_layers if discriminator_layers is not None else 4
+
+            patchgan_layers = n_blocks if n_blocks is not None else 3
             self.discriminator = PatchGANDiscriminator(
                 input_nc=self.config.Model.in_bands,
-                ndf=self.config.Discriminator.n_channels,
                 n_layers=patchgan_layers,
             )
         else:

--- a/utils/model_descriptions.py
+++ b/utils/model_descriptions.py
@@ -71,11 +71,26 @@ def print_model_summary(self):
     # ------------------------------------------------------------------
     # Discriminator Info
     # ------------------------------------------------------------------
+    d_type = getattr(self.config.Discriminator, "model_type", "standard")
+    d_blocks = getattr(self.config.Discriminator, "n_blocks", None)
+    effective_blocks = getattr(self.discriminator, "n_blocks", getattr(self.discriminator, "n_layers", d_blocks))
+    base_channels = getattr(self.discriminator, "base_channels", "N/A")
+    kernel_size = getattr(self.discriminator, "kernel_size", "N/A")
+    fc_size = getattr(self.discriminator, "fc_size", None)
+
+    if d_type == "patchgan":
+        d_desc = "PatchGAN"
+    else:
+        d_desc = "SRGAN"
+
     print(f"🧠 Discriminator")
-    print(f"   • Channels:          {self.config.Discriminator.n_channels}")
-    print(f"   • Blocks:            {self.config.Discriminator.n_blocks}")
-    print(f"   • Kernel Size:       {self.config.Discriminator.kernel_size}")
-    print(f"   • FC Layer Size:     {self.config.Discriminator.fc_size}")
+    print(f"   • Architecture:     {d_desc}")
+    if effective_blocks is not None:
+        print(f"   • Blocks/Layers:    {effective_blocks}")
+    print(f"   • Base Channels:    {base_channels}")
+    print(f"   • Kernel Size:      {kernel_size}")
+    if fc_size is not None:
+        print(f"   • FC Layer Size:    {fc_size}")
     print(f"   • Params:            {d_params:.2f} M\n")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- replace the discriminator configuration with a shared n_blocks parameter and hardcoded architecture defaults
- add a PatchGAN discriminator module adapted from the pix2pix reference and wire it into model construction
- update the SRGAN discriminator and model summary helpers to reflect the simplified settings

## Testing
- python -m compileall model

------
https://chatgpt.com/codex/tasks/task_e_68ea7c00e60c8327870bfa19963a3914