### PR TITLE
Add configurable LPIPS perceptual loss option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository provides:
 
 * 🧩 **Flexible generator**: choose block type `res`, `rcab`, `rrdb`, or `lka`; set `n_blocks`, `n_channels`, and `scale ∈ {2,4,8}`.
 * 🛰️ **Flexible inputs**: train on **any band layout** (e.g., S2 RGB‑NIR, 6‑band stacks, or custom multispectral sets). Normalization/denorm utilities provided.
-* ⚖️ **Flexible losses & weights**: combine L1, Spectral Angle Mapper, VGG19 perceptual MSE, Total Variation, PSNR/SSIM surrogates, and a BCE adversarial term with **per‑loss weights**.
+* ⚖️ **Flexible losses & weights**: combine L1, Spectral Angle Mapper, VGG19 or LPIPS perceptual distances, Total Variation, PSNR/SSIM surrogates, and a BCE adversarial term with **per‑loss weights**.
 * 🧪 **Robust training strategy**: generator **pretraining**, **linear adversarial loss ramp**, and **discriminator update schedules/curves**.
 * 📊 **Clear monitoring**: PSNR, SSIM, LPIPS, qualitative panels, and Weights & Biases logging.
 
@@ -50,7 +50,7 @@ This repository provides:
 |-----------|---------|-------------|
 | **Generators** | `SRResNet`, `res`, `rcab`, `rrdb`, `lka` | `Generator.model_type`, depth via `Generator.n_blocks`, width via `Generator.n_channels`, kernels and scale. |
 | **Discriminators** | `standard` SRGAN CNN, `patchgan` | `Discriminator.model_type`, granularity with `Discriminator.n_blocks`. |
-| **Content losses** | L1, Spectral Angle Mapper, VGG19 perceptual MSE, Total Variation, PSNR‑surrogate, SSIM‑surrogate | Weighted by `Training.Losses.*` (e.g. `l1_weight`, `sam_weight`, `perceptual_weight`, `tv_weight`, `psnr_weight`, `ssim_weight`). |
+| **Content losses** | L1, Spectral Angle Mapper, VGG19/LPIPS perceptual metrics, Total Variation, PSNR‑surrogate, SSIM‑surrogate | Weighted by `Training.Losses.*` (e.g. `l1_weight`, `sam_weight`, `perceptual_weight`, `perceptual_metric`, `tv_weight`, `psnr_weight`, `ssim_weight`). |
 | **Adversarial loss** | BCE‑with‑logits on real/fake logits | Warmup via `Training.pretrain_g_only`, ramped by `adv_loss_ramp_steps`, capped at `adv_loss_beta`, optional label smoothing. |
 
 The YAML keeps the SRGAN flexible: swap architectures or rebalance perceptual vs. spectral fidelity without touching the code.

--- a/configs/config_20m.yaml
+++ b/configs/config_20m.yaml
@@ -46,7 +46,8 @@ Training:
     # --- Content loss components (GeneratorContentLoss) ---
     l1_weight: 1.0             # L1 loss over all bands
     sam_weight: 0.05           # Spectral Angle Mapper loss
-    perceptual_weight: 0.1     # VGG-based perceptual MSE (3-band only)
+    perceptual_weight: 0.1     # Perceptual similarity term weight
+    perceptual_metric: 'vgg'   # ['vgg', 'lpips'] - LPIPS requires pip install lpips
     tv_weight: 0.0             # Total Variation regularization (optional)
 
     # --- Quality metric auxiliary losses (optional) ---


### PR DESCRIPTION
## Summary
- generalize the generator content loss to load either VGG or LPIPS perceptual metrics based on configuration
- update the default YAML and documentation to expose the new `perceptual_metric` selector and describe the LPIPS option

## Testing
- python -m compileall model/loss

------
https://chatgpt.com/codex/tasks/task_e_68ea928d123083278351504657a2baab