### PR TITLE
Fix SSIM reduction usage and ensure scalar metrics

### DIFF
--- a/model/loss/loss.py
+++ b/model/loss/loss.py
@@ -185,12 +185,19 @@ class GeneratorContentLoss(nn.Module):
             sr_metric = sen2_stretch(sr)
             hr_metric = sen2_stretch(hr)
             psnr = km.psnr(sr_metric, hr_metric, max_val=self.max_val)
+            ssim = km.ssim(
+                sr_metric,
+                hr_metric,
+                window_size=self.ssim_win,
+                max_val=self.max_val,
+            )
+
             if psnr.dim() > 0:
                 psnr = psnr.mean()
+            if ssim.dim() > 0:
+                ssim = ssim.mean()
+
             comps["psnr"] = psnr.detach()
-            comps["ssim"] = km.ssim(
-                sr_metric, hr_metric, window_size=self.ssim_win,
-                max_val=self.max_val, reduction="mean"
-            ).detach()
+            comps["ssim"] = ssim.detach()
 
         return comps


### PR DESCRIPTION
## Summary
- remove the unsupported reduction argument from the SSIM metric call
- ensure PSNR and SSIM metrics are reduced to scalar values when returned

## Testing
- not run (torch is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ea9f223a9c83279d876672c66f2331