### PR TITLE
Add selectable adversarial weight ramp schedule

### DIFF
--- a/configs/config_10m.yaml
+++ b/configs/config_10m.yaml
@@ -42,6 +42,7 @@ Training:
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up
+    adv_loss_schedule: 'sigmoid'  # Adversarial weight ramp type: ['linear', 'sigmoid']
 
     # --- Content loss components (GeneratorContentLoss) ---
     l1_weight: 1.0             # L1 loss over all bands

--- a/configs/config_20m.yaml
+++ b/configs/config_20m.yaml
@@ -42,6 +42,7 @@ Training:
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up
+    adv_loss_schedule: 'sigmoid'  # Adversarial weight ramp type: ['linear', 'sigmoid']
 
     # --- Content loss components (GeneratorContentLoss) ---
     l1_weight: 1.0             # L1 loss over all bands


### PR DESCRIPTION
## Summary
- allow choosing between linear and sigmoid adversarial weight ramp schedules via configuration
- default training configs set the sigmoid schedule explicitly to preserve existing behavior

## Testing
- python -m compileall model/SRGAN.py

------
https://chatgpt.com/codex/tasks/task_e_68ed0479e48c832795125b2ed53ad39a