### PR TITLE
Add MkDocs documentation site for SRGAN project

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,61 @@
+# Model Components
+
+Remote-Sensing-SRGAN builds on a modular Lightning implementation that lets you swap generator and discriminator backbones as well as plug in new loss terms. This section describes the main components and how they interact during training.
+
+## Lightning module
+
+The central `SRGAN_model` class orchestrates the entire training loop:
+
+* Loads configuration values from YAML via OmegaConf during initialisation.【F:model/SRGAN.py†L25-L43】
+* Instantiates the chosen generator, discriminator, and perceptual loss network through `get_models()`.【F:model/SRGAN.py†L59-L150】
+* Exposes `forward` for generator inference and `predict_step` for deployment-ready predictions with auto-normalisation and histogram matching.【F:model/SRGAN.py†L153-L192】
+* Implements Lightning hooks for adversarial training, including generator-only pretraining, adversarial ramp-up, and rich logging (see `training_step` and helpers).【F:model/SRGAN.py†L195-L320】
+
+## Generator zoo
+
+Pick the generator backbone by setting `Generator.model_type` in the config. The options map to classes under `model/generators/`:
+
+| Type | Description |
+|------|-------------|
+| `SRResNet` | Classic SRResNet with residual blocks sans batch norm; a strong baseline for content pretraining.【F:model/SRGAN.py†L64-L76】|
+| `res` | Flexible residual blocks with configurable depth/width defined in `FlexibleGenerator` (supports residual scaling).【F:model/SRGAN.py†L77-L101】【F:model/generators/flexible_generator.py†L1-L96】|
+| `rcab` | Residual channel attention blocks for finer texture modelling using the same flexible generator with RCAB building blocks.【F:model/generators/flexible_generator.py†L1-L96】【F:model/model_blocks/__init__.py†L144-L173】|
+| `rrdb` | Residual-in-residual dense blocks (ESRGAN-style) for deeper receptive fields, enabled through the flexible generator registry.【F:model/generators/flexible_generator.py†L21-L96】【F:model/model_blocks/__init__.py†L176-L213】|
+| `lka` | Large kernel attention variant approximating global receptive fields, useful for broad RS structures.【F:model/generators/flexible_generator.py†L21-L96】【F:model/model_blocks/__init__.py†L215-L249】|
+| `conditional_cgan` / `cgan` | Conditional GAN generator that injects latent noise and conditional embeddings in addition to the spectral input.【F:model/SRGAN.py†L88-L101】【F:model/generators/cgan_generator.py†L15-L137】|
+
+Each generator consumes `Model.in_bands` channels, expands to `Generator.n_channels` features, and upsamples by `Generator.scaling_factor` using pixel shuffle stages. Kernel sizes (`large_kernel_size`, `small_kernel_size`) tailor the receptive field for remote-sensing textures.【F:model/SRGAN.py†L64-L101】【F:model/generators/flexible_generator.py†L49-L96】
+
+## Discriminators
+
+Discriminator selection lives under `Discriminator.model_type`:
+
+* `standard`: The canonical SRGAN discriminator with adjustable depth (`n_blocks`), implemented in `model/descriminators/srgan_discriminator.py`. The constructor accepts `in_channels` (matching the number of input bands).【F:model/SRGAN.py†L102-L117】
+* `patchgan`: Patch-level discriminator inspired by pix2pix, parameterised by `n_layers` and automatically set from `n_blocks`. Good for local fidelity supervision on large tiles.【F:model/SRGAN.py†L118-L150】
+
+Because both discriminators receive multi-band inputs, the repo avoids hard-coding RGB assumptions and allows training on arbitrary spectral stacks.
+
+## Losses
+
+Generator training minimises a combination of content and adversarial losses:
+
+* **Content loss (`GeneratorContentLoss`)** combines weighted L1, spectral angle mapper (SAM), perceptual (VGG or LPIPS), and total variation terms as configured in the YAML file.【F:model/SRGAN.py†L34-L58】【F:model/loss/loss.py†L1-L210】
+* **Adversarial loss** uses `torch.nn.BCEWithLogitsLoss` against discriminator logits with optional label smoothing to improve stability.【F:model/SRGAN.py†L34-L58】
+
+During generator-only pretraining, the adversarial term is disabled; it ramps up to `adv_loss_beta` over `adv_loss_ramp_steps` iterations according to the chosen schedule (`linear` or `sigmoid`).【F:model/SRGAN.py†L34-L58】【F:configs/config_10m.yaml†L35-L70】
+
+## Normalisation and inference helpers
+
+Remote-sensing imagery often arrives as 0–10,000 scaled reflectance. `utils.spectral_helpers` provides `normalise_10k` for scaling to 0–1 and `histogram` for histogram matching. `predict_step` calls both utilities to ensure outputs match the statistical distribution of inputs before returning CPU tensors.【F:model/SRGAN.py†L160-L192】【F:utils/spectral_helpers.py†L53-L200】
+
+## Logging utilities
+
+Qualitative logging is handled via `utils.logging_helpers.plot_tensors`, which renders low-/super-/high-resolution panels for TensorBoard and Weights & Biases. The Lightning module invokes these helpers inside validation hooks so you can monitor spectral fidelity and artefacts during training.【F:model/SRGAN.py†L12-L16】【F:utils/logging_helpers.py†L1-L200】
+
+## Extending the model
+
+* Add new generator families by creating a file under `model/generators/` and wiring it into `SRGAN_model.get_models` plus `model/generators/__init__.py`.
+* Introduce alternative discriminators under `model/descriminators/` and add a new branch in `get_models`.
+* Extend content loss by editing `model/loss/loss.py`; the `GeneratorContentLoss` class already parses weights from the config.
+* For additional logging (e.g., metrics beyond PSNR/SSIM/LPIPS), modify the validation hooks inside `model/SRGAN.py`.
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,124 @@
+# Configuration Guide
+
+Remote-Sensing-SRGAN is intentionally configuration-first. Every YAML file under `configs/` controls the entire experiment lifecycle — from dataset selection to optimiser schedules. This page documents the key sections and explains how they map to the Python implementation.
+
+## Anatomy of a config file
+
+Each config follows the same structure as `configs/config_10m.yaml`:
+
+```yaml
+Data:
+  train_batch_size: 12
+  val_batch_size: 8
+  num_workers: 6
+  prefetch_factor: 2
+  dataset_type: "SISR_WW"
+
+Model:
+  in_bands: 6
+  continue_training: False
+  load_checkpoint: False
+
+Training:
+  pretrain_g_only: True
+  g_pretrain_steps: 15000
+  adv_loss_ramp_steps: 5000
+  label_smoothing: True
+  Losses:
+    adv_loss_beta: 1e-3
+    adv_loss_schedule: sigmoid
+    l1_weight: 1.0
+    sam_weight: 0.05
+    perceptual_weight: 0.1
+    perceptual_metric: vgg
+    tv_weight: 0.0
+    max_val: 1.0
+    ssim_win: 11
+
+Generator:
+  model_type: cgan
+  large_kernel_size: 9
+  small_kernel_size: 3
+  n_channels: 96
+  n_blocks: 32
+  scaling_factor: 8
+
+Discriminator:
+  model_type: standard
+  n_blocks: 8
+
+Optimizers:
+  optim_g_lr: 1e-4
+  optim_d_lr: 1e-4
+
+Schedulers:
+  metric: val_metrics/l1
+  patience_g: 100
+  patience_d: 100
+  factor_g: 0.5
+  factor_d: 0.5
+  verbose: True
+
+Logging:
+  num_val_images: 5
+```
+
+## Data block
+
+The data section controls loader throughput and selects the dataset implementation. The `dataset_type` key is forwarded to `data.data_utils.select_dataset`, which instantiates the proper dataset class and wraps it into a Lightning `DataModule` with the requested batch sizes and worker settings.【F:data/data_utils.py†L1-L95】【F:data/data_utils.py†L97-L150】
+
+### Available dataset types
+
+| Key | Description |
+|-----|-------------|
+| `S2_6b` | Loads Sentinel-2 SAFE chips with six 20 m bands (B05, B06, B07, B8A, B11, B12). Histogram-matched low-resolution inputs are synthesised on-the-fly. 【F:data/data_utils.py†L17-L48】|
+| `S2_4b` | Reuses the SAFE pipeline for four 10 m bands (B05, B04, B03, B02). Useful for RGB+NIR 4× tasks. 【F:data/data_utils.py†L50-L82】|
+| `SISR_WW` | Wraps the SEN2NAIP worldwide dataset for 4× cross-sensor training. Training/validation splits are constructed from a root directory. 【F:data/data_utils.py†L84-L95】|
+
+If you introduce a new dataset class, register it by adding another branch to `select_dataset` and exposing a new `dataset_type` value.
+
+## Model block
+
+The `Model` section captures properties that affect both training and checkpoint management:
+
+* `in_bands`: number of channels consumed by the generator and discriminator. This value is forwarded directly when models are instantiated.【F:model/SRGAN.py†L62-L100】
+* `load_checkpoint`: path to a Lightning checkpoint whose weights should initialise the model before training begins.【F:train.py†L34-L47】
+* `continue_training`: checkpoint to resume including optimiser states and scheduler counters (mapped to `Trainer(resume_from_checkpoint=...)`).【F:train.py†L34-L48】
+
+## Training block
+
+Training-related switches are consumed inside the Lightning module:
+
+* `pretrain_g_only`: number of initial steps where only generator updates run (adversarial term disabled).【F:model/SRGAN.py†L34-L43】
+* `g_pretrain_steps`: length of the generator-only warm-up window.【F:model/SRGAN.py†L34-L43】
+* `adv_loss_ramp_steps`: number of iterations over which the adversarial loss weight ramps to its target. The schedule shape is controlled by `Losses.adv_loss_schedule`.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L70】
+* `label_smoothing`: enables 0.9 real labels in the discriminator to reduce overconfidence.【F:model/SRGAN.py†L34-L43】
+
+The nested `Losses` dictionary is passed to `GeneratorContentLoss`, which mixes pixel-space (`l1_weight`), spectral (`sam_weight`), perceptual (`perceptual_weight` with `perceptual_metric`), and total-variation (`tv_weight`) losses. The final adversarial weight after ramp-up is `adv_loss_beta`. 【F:model/SRGAN.py†L44-L58】【F:configs/config_10m.yaml†L35-L70】
+
+## Generator and Discriminator blocks
+
+Generator parameters control the backbone constructed in `SRGAN_model.get_models`:
+
+* `model_type`: choose among `SRResNet`, `res`, `rcab`, `rrdb`, `lka`, or conditional GAN variants (`conditional_cgan`/`cgan`). Each path maps to a dedicated class under `model/generators/`.【F:model/SRGAN.py†L59-L101】
+* `n_channels`, `n_blocks`: width and depth of the residual trunk. These values are forwarded verbatim to the generator constructors.【F:model/SRGAN.py†L64-L101】
+* `scaling_factor`: upsampling factor (2×, 4×, or 8×). Passed into the generator to configure pixel-shuffle stages.【F:model/SRGAN.py†L64-L101】
+* `large_kernel_size`, `small_kernel_size`: head/tail and residual block kernel sizes to shape receptive field.【F:model/SRGAN.py†L64-L101】
+
+The discriminator section selects either the classic SRGAN CNN (`standard`) or a PatchGAN variant and optionally specifies convolutional depth via `n_blocks`. 【F:model/SRGAN.py†L102-L130】
+
+## Optimisers and schedulers
+
+Both the generator and discriminator use Adam optimisers with learning rates read from `Optimizers.optim_g_lr` and `Optimizers.optim_d_lr`. The Lightning module instantiates `ReduceLROnPlateau` schedulers using the parameters provided under `Schedulers` (`metric`, `patience_*`, `factor_*`, `verbose`).【F:model/SRGAN.py†L5-L12】【F:configs/config_10m.yaml†L103-L132】
+
+## Logging
+
+The `Logging` section controls qualitative outputs. During validation the model logs `num_val_images` panels via TensorBoard and Weights & Biases. The training script also wires in Weights & Biases, TensorBoard, and learning-rate monitors; edit this block if you want fewer images per epoch. 【F:configs/config_10m.yaml†L128-L132】【F:train.py†L59-L93】
+
+## Tips for custom configs
+
+* Keep configs under version control alongside experiment results — MkDocs can render them for quick reference.
+* Use OmegaConf variable interpolation if you need to reuse values across sections.
+* When experimenting with new datasets, add dataset-specific parameters (paths, band lists) under `Data` and consume them inside your dataset branch.
+* Prefer creating new YAML files rather than editing defaults; the training script accepts any path via `--config`.
+

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,53 @@
+# Data Pipelines
+
+Remote-Sensing-SRGAN ships with dataset loaders tailored to Sentinel-2 SAFE products and the SEN2NAIP worldwide corpus. All loaders produce `(lr, hr)` tensor pairs suitable for Lightning training and plug into the config-driven selector in `data/data_utils.py`.
+
+## Dataset selector
+
+`data.data_utils.select_dataset(config)` reads `config.Data.dataset_type` and constructs the appropriate dataset instances. The helper then wraps them into a minimal Lightning `DataModule` with configurable batch sizes, worker counts, and prefetch factors.【F:data/data_utils.py†L1-L150】
+
+```python
+pl_datamodule = select_dataset(config)
+train_loader = pl_datamodule.train_dataloader()
+val_loader = pl_datamodule.val_dataloader()
+```
+
+The selector currently supports three dataset families:
+
+### Sentinel-2 SAFE 6-band (`S2_6b`)
+
+* **Goal:** Train on six 20 m Sentinel-2 bands (B05, B06, B07, B8A, B11, B12) stacked into a single tensor.
+* **Implementation:** Uses `data/SEN2_SAFE/S2_6b_ds.py::S2SAFEDataset` to read a manifest of pre-windowed chips. The dataset handles normalisation, band ordering, LR synthesis via anti-aliased downsampling, and invalid chip filtering.【F:data/data_utils.py†L17-L48】
+* **Configuration hooks:** `Generator.scaling_factor` determines the SR scale (2×/4×/8×). Hard-coded manifest path and band order can be promoted to config keys if you need to vary them frequently.
+
+### Sentinel-2 SAFE 4-band (`S2_4b`)
+
+* **Goal:** Focus on RGB+NIR super-resolution using four 10 m bands (B05, B04, B03, B02).
+* **Implementation:** Reuses `S2SAFEDataset` with an alternative band list. Despite the 10 m intent, the manifest path currently points to the 20 m JSON; adjust it if you curate a dedicated 10 m manifest.【F:data/data_utils.py†L50-L82】
+* **Configuration hooks:** Same as `S2_6b`; update band order and manifest in the dataset branch if you require different inputs.
+
+### SEN2NAIP Worldwide (`SISR_WW`)
+
+* **Goal:** Leverage Taco Foundation’s SEN2NAIP pairs where Sentinel-2 observations are paired with NAIP aerial imagery at 4× resolution.
+* **Implementation:** The `SISRWorldWide` dataset (under `data/SISR_WW/`) reads the dataset root, honours `split` arguments (`train`/`val`), and returns aligned `(lr, hr)` samples. The data selector simply instantiates train/val splits pointing to `/data3/SEN2NAIP_global` by default.【F:data/data_utils.py†L84-L95】
+* **Configuration hooks:** Update the root path or expose it through the config to point at your local dataset copy.
+
+## Building new datasets
+
+Adding a dataset follows three simple steps:
+
+1. **Implement the dataset class** under `data/<name>/` with `__len__` and `__getitem__` returning `(lr, hr)` arrays or tensors.
+2. **Register the selector** by adding a new `elif` branch in `select_dataset` that instantiates your dataset and passes the config values you need.
+3. **Expose configuration keys** under `Data` (e.g., `manifest_path`, `bands_keep`) so experiments remain reproducible without code edits.【F:data/data_utils.py†L1-L95】
+
+## DataLoader configuration
+
+`datamodule_from_datasets` handles DataLoader construction and mirrors config values to PyTorch Lightning:
+
+* `train_batch_size` / `val_batch_size`: separate sizes for each split, falling back to `Data.batch_size` if provided.【F:data/data_utils.py†L107-L130】
+* `num_workers`: enables multi-process loading; when set to zero the helper disables persistent workers and prefetch factors.【F:data/data_utils.py†L108-L140】
+* `prefetch_factor`: forwarded when workers > 0 to balance host-device throughput.【F:data/data_utils.py†L110-L140】
+* `shuffle`: enabled for both train and validation to improve spatial diversity in evaluation batches (intentional design choice).【F:data/data_utils.py†L125-L140】
+
+Because the `DataModule` is assembled dynamically, you can plug in custom datasets without changing the training loop — just add a branch and update your YAML.
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,87 @@
+# Getting Started
+
+This guide walks through environment setup, configuration management, and the minimal commands required to launch a Remote-Sensing-SRGAN experiment.
+
+## Prerequisites
+
+* Python 3.10 (required by the pinned PyTorch 1.13 / torchvision 0.14 wheels).【F:README.md†L45-L73】
+* CUDA-capable GPU if you plan to train on large Sentinel-2 chips (the default trainer is configured for GPU execution).【F:train.py†L69-L90】
+* Optional: Weights & Biases account for experiment tracking and Git LFS if you plan to download large datasets.
+
+## Create an environment
+
+```bash
+# Clone the repository
+git clone https://github.com/ESAOpenSR/Remote-Sensing-SRGAN.git
+cd Remote-Sensing-SRGAN
+
+# (optional) Create a Python 3.10 virtual environment
+python3.10 -m venv .venv
+source .venv/bin/activate
+
+# (recommended) Upgrade pip
+python -m pip install --upgrade pip
+
+# Install runtime dependencies
+pip install -r requirements.txt
+```
+
+If the main PyPI index cannot resolve the exact PyTorch build, install the wheel directly from the official index before `pip install -r requirements.txt`:
+
+```bash
+pip install torch==1.13.1 torchvision==0.14.1 --index-url https://download.pytorch.org/whl/cu117
+```
+
+## Configure your experiment
+
+All experiment settings live in YAML files under `configs/`. The `config_20m.yaml` template targets Sentinel-2 20 m inputs, while `config_10m.yaml` demonstrates 10 m multi-band training. Key sections include:
+
+* `Data`: batch sizes, worker counts, and dataset selector (`S2_6b`, `S2_4b`, `SISR_WW`, etc.).【F:configs/config_10m.yaml†L12-L33】
+* `Model`: input band count and checkpoint loading behaviour.【F:configs/config_10m.yaml†L22-L28】
+* `Training`: warm-up lengths, adversarial ramp strategy, and loss weights.【F:configs/config_10m.yaml†L35-L70】
+* `Generator` / `Discriminator`: architecture choices and scale factor.【F:configs/config_10m.yaml†L73-L101】
+* `Optimizers`, `Schedulers`, `Logging`: learning rates, ReduceLROnPlateau settings, and validation visualisations.【F:configs/config_10m.yaml†L103-L132】
+
+Duplicate a config file if you need to adjust parameters without touching the defaults:
+
+```bash
+cp configs/config_20m.yaml configs/my_experiment.yaml
+```
+
+## Launch training
+
+Use the training script with the desired YAML file:
+
+```bash
+python train.py --config configs/my_experiment.yaml
+```
+
+Under the hood the script:
+
+1. Loads the configuration via OmegaConf and instantiates the Lightning `SRGAN_model`.【F:train.py†L24-L48】
+2. Selects and wraps the dataset into a Lightning `DataModule` based on `Data.dataset_type`.【F:train.py†L49-L57】【F:data/data_utils.py†L1-L95】
+3. Configures Weights & Biases, TensorBoard, and learning rate monitoring callbacks. 【F:train.py†L59-L93】
+4. Starts training with GPU acceleration enabled by default. 【F:train.py†L69-L90】
+
+Training logs, checkpoints, and exported validation panels are written into `logs/` alongside the W&B run.
+
+## Resume or fine-tune
+
+Two checkpoint switches let you reuse trained weights without editing Python code:
+
+* `Model.load_checkpoint`: path to a Lightning checkpoint whose weights should initialise the generator/discriminator before training begins. 【F:train.py†L34-L47】
+* `Model.continue_training`: path to a checkpoint that should be fully resumed (optimizer states, schedulers, etc.). Leave both as `False` to start from scratch.【F:train.py†L34-L47】
+
+## Inference quick peek
+
+For offline inference, instantiate `SRGAN_model` and call `predict_step` with low-resolution tensors. The method auto-normalises Sentinel-2 style inputs, runs the generator, histogram matches the output, and denormalises back to the original range.【F:model/SRGAN.py†L103-L144】
+
+```python
+from model.SRGAN import SRGAN_model
+model = SRGAN_model(config_file_path="configs/my_experiment.yaml")
+model.eval()
+
+with torch.no_grad():
+    sr = model.predict_step(lr_tensor)
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# Remote-Sensing SRGAN
+
+Remote-Sensing-SRGAN is a research-grade training stack for single-image super-resolution (SISR) of multispectral satellite imagery. It wraps a flexible generator/discriminator design, configurable loss suite, and remote-sensing specific data pipelines behind a configuration-first workflow. The implementation is optimised for Sentinel-2 but can be adapted to other sensors that provide paired low-/high-resolution observations.
+
+!!! info "Why another SRGAN?"
+    Training GANs on multi-band Earth observation data is notoriously brittle. This project codifies the training heuristics that have proven stable in production — generator pretraining, adversarial weight ramp-up, and configurable discriminator cadence — while exposing every knob through YAML. The goal is to make it easy to reproduce remote-sensing SR experiments without rewriting boilerplate.
+
+## Project highlights
+
+* **Flexible generator zoo.** Choose between SRResNet, residual, RCAB, RRDB, large-kernel attention, or conditional GAN backbones with scale factors from 2×–8×.【F:model/SRGAN.py†L59-L101】
+* **Pluggable losses.** Combine pixel, spectral, perceptual, adversarial, and total-variation terms with independent weights and activation schedules.【F:model/SRGAN.py†L44-L58】【F:configs/config_10m.yaml†L35-L70】
+* **Remote-sensing ready datasets.** Sentinel-2 SAFE windowing and the SEN2NAIP worldwide pairs are built in, with Lightning datamodules created on the fly from the config.【F:data/data_utils.py†L1-L95】
+* **Stabilised training flow.** Generator-only warm-up, adversarial ramp-up, discriminator scheduling, and Lightning callbacks are wired into the training script.【F:train.py†L19-L93】【F:model/SRGAN.py†L34-L43】
+* **Comprehensive logging.** TensorBoard visualisations, Weights & Biases tracking, and qualitative inspection panels are emitted during training.【F:train.py†L59-L93】【F:model/SRGAN.py†L12-L16】
+
+## Repository layout
+
+```
+SISR-RS-SRGAN/
+├── configs/              # YAML experiment definitions
+├── data/                 # Dataset implementations and helpers
+├── model/                # LightningModule, generators, discriminators, losses
+├── utils/                # Logging and spectral utilities
+├── train.py              # Training entry point
+└── docs/                 # MkDocs site (you are here)
+```
+
+## Next steps
+
+* Head to [Getting Started](getting-started.md) for environment setup and the minimal training command.
+* Review the [Configuration Guide](configuration.md) to understand every YAML switch.
+* Dive into [Model Components](architecture.md) for generator and discriminator details.
+* Explore [Data Pipelines](data.md) for dataset specifics and extension tips.
+

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,0 +1,49 @@
+# Training Workflow
+
+Remote-Sensing-SRGAN uses PyTorch Lightning to manage training loops, logging, and checkpointing. This guide explains the runtime workflow, callbacks, and practical tips for stable training on large remote-sensing datasets.
+
+## End-to-end flow
+
+1. **Configuration load:** `train.py` reads the YAML file supplied via `--config` and passes it to `SRGAN_model`.【F:train.py†L19-L47】
+2. **Dataset selection:** `select_dataset` constructs train/validation datasets and wraps them into a Lightning `DataModule`. Dataset statistics are printed for sanity. 【F:data/data_utils.py†L1-L95】【F:data/data_utils.py†L121-L140】
+3. **Logger setup:** Weights & Biases, TensorBoard, and a learning-rate monitor are initialised. Checkpoints are saved under `logs/<project>/<timestamp>/`.【F:train.py†L59-L93】
+4. **Training loop:** `Trainer.fit` launches GPU-accelerated training with callbacks for checkpointing, early stopping, and LR monitoring. 【F:train.py†L69-L96】
+
+## Lightning hooks inside `SRGAN_model`
+
+* `training_step`: Receives both generator and discriminator optimisers (Lightning’s GAN pattern). Handles generator-only pretraining, adversarial ramp-up, and logging of scalar losses/metrics.
+* `validation_step`: Generates super-resolved outputs for qualitative logging, computes metrics (PSNR, SSIM, LPIPS if configured), and stores them for epoch-level aggregation.
+* `configure_optimizers`: Creates two Adam optimisers plus `ReduceLROnPlateau` schedulers based on config values. 【F:model/SRGAN.py†L5-L12】
+* `on_validation_epoch_end`: Uses `utils.logging_helpers.plot_tensors` to push LR/SR/HR panels to TensorBoard and Weights & Biases. 【F:model/SRGAN.py†L12-L16】【F:utils/logging_helpers.py†L1-L200】
+
+Inspect `model/SRGAN.py` for detailed comments describing each step of the training loop and logging behaviour.
+
+## Callbacks and logging
+
+`train.py` wires in several Lightning callbacks out of the box:
+
+| Callback | Purpose |
+|----------|---------|
+| `ModelCheckpoint` | Saves `last.ckpt` and top-2 checkpoints based on `Schedulers.metric` (default: `val_metrics/l1`).【F:train.py†L69-L93】|
+| `LearningRateMonitor` | Logs generator/discriminator learning rates each epoch to W&B/TensorBoard.【F:train.py†L88-L93】|
+| `EarlyStopping` | Monitors the same validation metric with large patience (250 epochs) to guard against divergence. 【F:train.py†L80-L88】|
+
+Weights & Biases is configured with `project="SRGAN_6bands"` and entity `opensr`. Set the `WANDB_PROJECT` or edit the script if you need per-experiment projects. TensorBoard logs are stored in `logs/` alongside W&B run data.【F:train.py†L59-L93】
+
+## Adversarial training schedule
+
+GAN training is stabilised through three mechanisms:
+
+* **Generator pretraining:** For the first `Training.g_pretrain_steps`, only the generator optimiser runs; the discriminator is skipped. This lets the generator learn a strong content prior before adversarial updates start.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L52】
+* **Adversarial ramp-up:** After pretraining, the adversarial loss weight increases linearly or sigmoidally over `Training.adv_loss_ramp_steps` until it reaches `Losses.adv_loss_beta`.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L70】
+* **Label smoothing:** When `Training.label_smoothing=True`, real labels are reduced to 0.9 to prevent discriminator overconfidence.【F:model/SRGAN.py†L34-L43】
+
+These heuristics reduce mode collapse and stabilise training on multi-spectral inputs where illumination and texture vary drastically between bands.
+
+## Practical tips
+
+* Monitor PSNR/SSIM/LPIPS in W&B to detect spectral artefacts early. If LPIPS diverges while PSNR improves, consider increasing `Losses.perceptual_weight`.
+* Use moderate `train_batch_size` values (8–16) to balance GPU utilisation and dataset variety. Increase `Data.prefetch_factor` when `num_workers > 0` to keep GPUs busy.【F:data/data_utils.py†L97-L140】
+* To benchmark architectures quickly, reuse trained generators by setting `Model.load_checkpoint` and adjusting only the discriminator or loss weights.
+* Keep an eye on GPU memory when scaling `Generator.n_blocks` and `n_channels`; RRDB and LKA variants are heavier than SRResNet.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,34 @@
+site_name: Remote-Sensing SRGAN Docs
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - toc.integrate
+    - content.code.annotate
+  palette:
+    - scheme: default
+      primary: teal
+      accent: deep orange
+repo_url: https://github.com/ESAOpenSR/Remote-Sensing-SRGAN
+repo_name: ESAOpenSR/Remote-Sensing-SRGAN
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - User Guide:
+      - Configuration: configuration.md
+      - Training Workflow: training.md
+      - Data Pipelines: data.md
+      - Model Components: architecture.md
+markdown_extensions:
+  - admonition
+  - codehilite
+  - footnotes
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true


### PR DESCRIPTION
## Summary
- add a MkDocs Material configuration for the project documentation
- document installation, configuration, training workflow, data pipelines, and model components using repo-specific details
- create a new docs/ site landing page to navigate the user guide sections

## Testing
- mkdocs build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed0757a7388327ba118dea916bd4dd