### PR TITLE
Use pymdownx snippets to embed live code in docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,73 +7,24 @@ Remote-Sensing-SRGAN is intentionally configuration-first. Every YAML file under
 Each config follows the same structure as `configs/config_10m.yaml`:
 
 ```yaml
-Data:
-  train_batch_size: 12
-  val_batch_size: 8
-  num_workers: 6
-  prefetch_factor: 2
-  dataset_type: "SISR_WW"
-
-Model:
-  in_bands: 6
-  continue_training: False
-  load_checkpoint: False
-
-Training:
-  pretrain_g_only: True
-  g_pretrain_steps: 15000
-  adv_loss_ramp_steps: 5000
-  label_smoothing: True
-  Losses:
-    adv_loss_beta: 1e-3
-    adv_loss_schedule: sigmoid
-    l1_weight: 1.0
-    sam_weight: 0.05
-    perceptual_weight: 0.1
-    perceptual_metric: vgg
-    tv_weight: 0.0
-    max_val: 1.0
-    ssim_win: 11
-
-Generator:
-  model_type: cgan
-  large_kernel_size: 9
-  small_kernel_size: 3
-  n_channels: 96
-  n_blocks: 32
-  scaling_factor: 8
-
-Discriminator:
-  model_type: standard
-  n_blocks: 8
-
-Optimizers:
-  optim_g_lr: 1e-4
-  optim_d_lr: 1e-4
-
-Schedulers:
-  metric: val_metrics/l1
-  patience_g: 100
-  patience_d: 100
-  factor_g: 0.5
-  factor_d: 0.5
-  verbose: True
-
-Logging:
-  num_val_images: 5
+--8<-- "../configs/config_10m.yaml:lines=12-132"
 ```
 
 ## Data block
 
-The data section controls loader throughput and selects the dataset implementation. The `dataset_type` key is forwarded to `data.data_utils.select_dataset`, which instantiates the proper dataset class and wraps it into a Lightning `DataModule` with the requested batch sizes and worker settings.【F:data/data_utils.py†L1-L95】【F:data/data_utils.py†L97-L150】
+The data section controls loader throughput and selects the dataset implementation. The `dataset_type` key is forwarded to `data.data_utils.select_dataset`, which instantiates the proper dataset class and wraps it into a Lightning `DataModule` with the requested batch sizes and worker settings.
+
+```python
+--8<-- "../data/data_utils.py:lines=1-150"
+```
 
 ### Available dataset types
 
 | Key | Description |
 |-----|-------------|
-| `S2_6b` | Loads Sentinel-2 SAFE chips with six 20 m bands (B05, B06, B07, B8A, B11, B12). Histogram-matched low-resolution inputs are synthesised on-the-fly. 【F:data/data_utils.py†L17-L48】|
-| `S2_4b` | Reuses the SAFE pipeline for four 10 m bands (B05, B04, B03, B02). Useful for RGB+NIR 4× tasks. 【F:data/data_utils.py†L50-L82】|
-| `SISR_WW` | Wraps the SEN2NAIP worldwide dataset for 4× cross-sensor training. Training/validation splits are constructed from a root directory. 【F:data/data_utils.py†L84-L95】|
+| `S2_6b` | Loads Sentinel-2 SAFE chips with six 20 m bands (B05, B06, B07, B8A, B11, B12). Histogram-matched low-resolution inputs are synthesised on-the-fly. |
+| `S2_4b` | Reuses the SAFE pipeline for four 10 m bands (B05, B04, B03, B02). Useful for RGB+NIR 4× tasks. |
+| `SISR_WW` | Wraps the SEN2NAIP worldwide dataset for 4× cross-sensor training. Training/validation splits are constructed from a root directory. |
 
 If you introduce a new dataset class, register it by adding another branch to `select_dataset` and exposing a new `dataset_type` value.
 
@@ -81,39 +32,83 @@ If you introduce a new dataset class, register it by adding another branch to `s
 
 The `Model` section captures properties that affect both training and checkpoint management:
 
-* `in_bands`: number of channels consumed by the generator and discriminator. This value is forwarded directly when models are instantiated.【F:model/SRGAN.py†L62-L100】
-* `load_checkpoint`: path to a Lightning checkpoint whose weights should initialise the model before training begins.【F:train.py†L34-L47】
-* `continue_training`: checkpoint to resume including optimiser states and scheduler counters (mapped to `Trainer(resume_from_checkpoint=...)`).【F:train.py†L34-L48】
+* `in_bands`: number of channels consumed by the generator and discriminator. This value is forwarded directly when models are instantiated.
+* `load_checkpoint`: path to a Lightning checkpoint whose weights should initialise the model before training begins.
+* `continue_training`: checkpoint to resume including optimiser states and scheduler counters (mapped to `Trainer(resume_from_checkpoint=...)`).
+
+```python
+--8<-- "../model/SRGAN.py:lines=62-118"
+```
+
+```python
+--8<-- "../train.py:lines=34-48"
+```
 
 ## Training block
 
 Training-related switches are consumed inside the Lightning module:
 
-* `pretrain_g_only`: number of initial steps where only generator updates run (adversarial term disabled).【F:model/SRGAN.py†L34-L43】
-* `g_pretrain_steps`: length of the generator-only warm-up window.【F:model/SRGAN.py†L34-L43】
-* `adv_loss_ramp_steps`: number of iterations over which the adversarial loss weight ramps to its target. The schedule shape is controlled by `Losses.adv_loss_schedule`.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L70】
-* `label_smoothing`: enables 0.9 real labels in the discriminator to reduce overconfidence.【F:model/SRGAN.py†L34-L43】
+* `pretrain_g_only`: number of initial steps where only generator updates run (adversarial term disabled).
+* `g_pretrain_steps`: length of the generator-only warm-up window.
+* `adv_loss_ramp_steps`: number of iterations over which the adversarial loss weight ramps to its target. The schedule shape is controlled by `Losses.adv_loss_schedule`.
+* `label_smoothing`: enables 0.9 real labels in the discriminator to reduce overconfidence.
 
-The nested `Losses` dictionary is passed to `GeneratorContentLoss`, which mixes pixel-space (`l1_weight`), spectral (`sam_weight`), perceptual (`perceptual_weight` with `perceptual_metric`), and total-variation (`tv_weight`) losses. The final adversarial weight after ramp-up is `adv_loss_beta`. 【F:model/SRGAN.py†L44-L58】【F:configs/config_10m.yaml†L35-L70】
+```python
+--8<-- "../model/SRGAN.py:lines=34-58"
+```
+
+The nested `Losses` dictionary is passed to `GeneratorContentLoss`, which mixes pixel-space (`l1_weight`), spectral (`sam_weight`), perceptual (`perceptual_weight` with `perceptual_metric`), and total-variation (`tv_weight`) losses. The final adversarial weight after ramp-up is `adv_loss_beta`.
+
+```yaml
+--8<-- "../configs/config_10m.yaml:lines=35-70"
+```
+
+```python
+--8<-- "../model/loss/loss.py:lines=1-210"
+```
 
 ## Generator and Discriminator blocks
 
 Generator parameters control the backbone constructed in `SRGAN_model.get_models`:
 
-* `model_type`: choose among `SRResNet`, `res`, `rcab`, `rrdb`, `lka`, or conditional GAN variants (`conditional_cgan`/`cgan`). Each path maps to a dedicated class under `model/generators/`.【F:model/SRGAN.py†L59-L101】
-* `n_channels`, `n_blocks`: width and depth of the residual trunk. These values are forwarded verbatim to the generator constructors.【F:model/SRGAN.py†L64-L101】
-* `scaling_factor`: upsampling factor (2×, 4×, or 8×). Passed into the generator to configure pixel-shuffle stages.【F:model/SRGAN.py†L64-L101】
-* `large_kernel_size`, `small_kernel_size`: head/tail and residual block kernel sizes to shape receptive field.【F:model/SRGAN.py†L64-L101】
+* `model_type`: choose among `SRResNet`, `res`, `rcab`, `rrdb`, `lka`, or conditional GAN variants (`conditional_cgan`/`cgan`). Each path maps to a dedicated class under `model/generators/`.
+* `n_channels`, `n_blocks`: width and depth of the residual trunk. These values are forwarded verbatim to the generator constructors.
+* `scaling_factor`: upsampling factor (2×, 4×, or 8×). Passed into the generator to configure pixel-shuffle stages.
+* `large_kernel_size`, `small_kernel_size`: head/tail and residual block kernel sizes to shape receptive field.
 
-The discriminator section selects either the classic SRGAN CNN (`standard`) or a PatchGAN variant and optionally specifies convolutional depth via `n_blocks`. 【F:model/SRGAN.py†L102-L130】
+```python
+--8<-- "../model/SRGAN.py:lines=72-150"
+```
+
+The discriminator section selects either the classic SRGAN CNN (`standard`) or a PatchGAN variant and optionally specifies convolutional depth via `n_blocks`.
+
+```python
+--8<-- "../model/descriminators/srgan_discriminator.py:lines=1-71"
+```
 
 ## Optimisers and schedulers
 
-Both the generator and discriminator use Adam optimisers with learning rates read from `Optimizers.optim_g_lr` and `Optimizers.optim_d_lr`. The Lightning module instantiates `ReduceLROnPlateau` schedulers using the parameters provided under `Schedulers` (`metric`, `patience_*`, `factor_*`, `verbose`).【F:model/SRGAN.py†L5-L12】【F:configs/config_10m.yaml†L103-L132】
+Both the generator and discriminator use Adam optimisers with learning rates read from `Optimizers.optim_g_lr` and `Optimizers.optim_d_lr`. The Lightning module instantiates `ReduceLROnPlateau` schedulers using the parameters provided under `Schedulers` (`metric`, `patience_*`, `factor_*`, `verbose`).
+
+```python
+--8<-- "../model/SRGAN.py:lines=408-443"
+```
+
+```yaml
+--8<-- "../configs/config_10m.yaml:lines=103-132"
+```
 
 ## Logging
 
-The `Logging` section controls qualitative outputs. During validation the model logs `num_val_images` panels via TensorBoard and Weights & Biases. The training script also wires in Weights & Biases, TensorBoard, and learning-rate monitors; edit this block if you want fewer images per epoch. 【F:configs/config_10m.yaml†L128-L132】【F:train.py†L59-L93】
+The `Logging` section controls qualitative outputs. During validation the model logs `num_val_images` panels via TensorBoard and Weights & Biases. The training script also wires in Weights & Biases, TensorBoard, and learning-rate monitors; edit this block if you want fewer images per epoch.
+
+```yaml
+--8<-- "../configs/config_10m.yaml:lines=128-132"
+```
+
+```python
+--8<-- "../train.py:lines=59-93"
+```
 
 ## Tips for custom configs
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -4,7 +4,11 @@ Remote-Sensing-SRGAN ships with dataset loaders tailored to Sentinel-2 SAFE prod
 
 ## Dataset selector
 
-`data.data_utils.select_dataset(config)` reads `config.Data.dataset_type` and constructs the appropriate dataset instances. The helper then wraps them into a minimal Lightning `DataModule` with configurable batch sizes, worker counts, and prefetch factors.【F:data/data_utils.py†L1-L150】
+`data.data_utils.select_dataset(config)` reads `config.Data.dataset_type` and constructs the appropriate dataset instances. The helper then wraps them into a minimal Lightning `DataModule` with configurable batch sizes, worker counts, and prefetch factors.
+
+```python
+--8<-- "../data/data_utils.py:lines=1-150"
+```
 
 ```python
 pl_datamodule = select_dataset(config)
@@ -17,19 +21,31 @@ The selector currently supports three dataset families:
 ### Sentinel-2 SAFE 6-band (`S2_6b`)
 
 * **Goal:** Train on six 20 m Sentinel-2 bands (B05, B06, B07, B8A, B11, B12) stacked into a single tensor.
-* **Implementation:** Uses `data/SEN2_SAFE/S2_6b_ds.py::S2SAFEDataset` to read a manifest of pre-windowed chips. The dataset handles normalisation, band ordering, LR synthesis via anti-aliased downsampling, and invalid chip filtering.【F:data/data_utils.py†L17-L48】
+* **Implementation:** Uses `data/SEN2_SAFE/S2_6b_ds.py::S2SAFEDataset` to read a manifest of pre-windowed chips. The dataset handles normalisation, band ordering, LR synthesis via anti-aliased downsampling, and invalid chip filtering.
+
+```python
+--8<-- "../data/data_utils.py:lines=17-48"
+```
 * **Configuration hooks:** `Generator.scaling_factor` determines the SR scale (2×/4×/8×). Hard-coded manifest path and band order can be promoted to config keys if you need to vary them frequently.
 
 ### Sentinel-2 SAFE 4-band (`S2_4b`)
 
 * **Goal:** Focus on RGB+NIR super-resolution using four 10 m bands (B05, B04, B03, B02).
-* **Implementation:** Reuses `S2SAFEDataset` with an alternative band list. Despite the 10 m intent, the manifest path currently points to the 20 m JSON; adjust it if you curate a dedicated 10 m manifest.【F:data/data_utils.py†L50-L82】
+* **Implementation:** Reuses `S2SAFEDataset` with an alternative band list. Despite the 10 m intent, the manifest path currently points to the 20 m JSON; adjust it if you curate a dedicated 10 m manifest.
+
+```python
+--8<-- "../data/data_utils.py:lines=50-82"
+```
 * **Configuration hooks:** Same as `S2_6b`; update band order and manifest in the dataset branch if you require different inputs.
 
 ### SEN2NAIP Worldwide (`SISR_WW`)
 
 * **Goal:** Leverage Taco Foundation’s SEN2NAIP pairs where Sentinel-2 observations are paired with NAIP aerial imagery at 4× resolution.
-* **Implementation:** The `SISRWorldWide` dataset (under `data/SISR_WW/`) reads the dataset root, honours `split` arguments (`train`/`val`), and returns aligned `(lr, hr)` samples. The data selector simply instantiates train/val splits pointing to `/data3/SEN2NAIP_global` by default.【F:data/data_utils.py†L84-L95】
+* **Implementation:** The `SISRWorldWide` dataset (under `data/SISR_WW/`) reads the dataset root, honours `split` arguments (`train`/`val`), and returns aligned `(lr, hr)` samples. The data selector simply instantiates train/val splits pointing to `/data3/SEN2NAIP_global` by default.
+
+```python
+--8<-- "../data/data_utils.py:lines=84-95"
+```
 * **Configuration hooks:** Update the root path or expose it through the config to point at your local dataset copy.
 
 ## Building new datasets
@@ -38,16 +54,24 @@ Adding a dataset follows three simple steps:
 
 1. **Implement the dataset class** under `data/<name>/` with `__len__` and `__getitem__` returning `(lr, hr)` arrays or tensors.
 2. **Register the selector** by adding a new `elif` branch in `select_dataset` that instantiates your dataset and passes the config values you need.
-3. **Expose configuration keys** under `Data` (e.g., `manifest_path`, `bands_keep`) so experiments remain reproducible without code edits.【F:data/data_utils.py†L1-L95】
+3. **Expose configuration keys** under `Data` (e.g., `manifest_path`, `bands_keep`) so experiments remain reproducible without code edits.
+
+```python
+--8<-- "../data/data_utils.py:lines=1-95"
+```
 
 ## DataLoader configuration
 
 `datamodule_from_datasets` handles DataLoader construction and mirrors config values to PyTorch Lightning:
 
-* `train_batch_size` / `val_batch_size`: separate sizes for each split, falling back to `Data.batch_size` if provided.【F:data/data_utils.py†L107-L130】
-* `num_workers`: enables multi-process loading; when set to zero the helper disables persistent workers and prefetch factors.【F:data/data_utils.py†L108-L140】
-* `prefetch_factor`: forwarded when workers > 0 to balance host-device throughput.【F:data/data_utils.py†L110-L140】
-* `shuffle`: enabled for both train and validation to improve spatial diversity in evaluation batches (intentional design choice).【F:data/data_utils.py†L125-L140】
+* `train_batch_size` / `val_batch_size`: separate sizes for each split, falling back to `Data.batch_size` if provided.
+* `num_workers`: enables multi-process loading; when set to zero the helper disables persistent workers and prefetch factors.
+* `prefetch_factor`: forwarded when workers > 0 to balance host-device throughput.
+* `shuffle`: enabled for both train and validation to improve spatial diversity in evaluation batches (intentional design choice).
+
+```python
+--8<-- "../data/data_utils.py:lines=97-150"
+```
 
 Because the `DataModule` is assembled dynamically, you can plug in custom datasets without changing the training loop — just add a branch and update your YAML.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,53 @@ Remote-Sensing-SRGAN is a research-grade training stack for single-image super-r
 
 ## Project highlights
 
-* **Flexible generator zoo.** Choose between SRResNet, residual, RCAB, RRDB, large-kernel attention, or conditional GAN backbones with scale factors from 2×–8×.【F:model/SRGAN.py†L59-L101】
-* **Pluggable losses.** Combine pixel, spectral, perceptual, adversarial, and total-variation terms with independent weights and activation schedules.【F:model/SRGAN.py†L44-L58】【F:configs/config_10m.yaml†L35-L70】
-* **Remote-sensing ready datasets.** Sentinel-2 SAFE windowing and the SEN2NAIP worldwide pairs are built in, with Lightning datamodules created on the fly from the config.【F:data/data_utils.py†L1-L95】
-* **Stabilised training flow.** Generator-only warm-up, adversarial ramp-up, discriminator scheduling, and Lightning callbacks are wired into the training script.【F:train.py†L19-L93】【F:model/SRGAN.py†L34-L43】
-* **Comprehensive logging.** TensorBoard visualisations, Weights & Biases tracking, and qualitative inspection panels are emitted during training.【F:train.py†L59-L93】【F:model/SRGAN.py†L12-L16】
+### Flexible generator zoo
+
+Choose between SRResNet, residual, RCAB, RRDB, large-kernel attention, or conditional GAN backbones with scale factors from 2×–8×.
+
+```python
+--8<-- "../model/SRGAN.py:lines=72-118"
+```
+
+### Pluggable losses
+
+Pixel, spectral, perceptual, adversarial, and total-variation terms can be mixed with independent weights and activation schedules.
+
+```python
+--8<-- "../model/SRGAN.py:lines=34-58"
+```
+
+```yaml
+--8<-- "../configs/config_10m.yaml:lines=35-70"
+```
+
+### Remote-sensing ready datasets
+
+Sentinel-2 SAFE windowing and the SEN2NAIP worldwide pairs are built in, with Lightning datamodules created on the fly from the configuration.
+
+```python
+--8<-- "../data/data_utils.py:lines=1-95"
+```
+
+### Stabilised training flow
+
+Generator-only warm-up, adversarial ramp-up, discriminator scheduling, and Lightning callbacks are wired into the training script.
+
+```python
+--8<-- "../train.py:lines=19-93"
+```
+
+### Comprehensive logging
+
+TensorBoard visualisations, Weights & Biases tracking, and qualitative inspection panels are emitted during training.
+
+```python
+--8<-- "../model/SRGAN.py:lines=12-16"
+```
+
+```python
+--8<-- "../train.py:lines=59-93"
+```
 
 ## Repository layout
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -4,17 +4,33 @@ Remote-Sensing-SRGAN uses PyTorch Lightning to manage training loops, logging, a
 
 ## End-to-end flow
 
-1. **Configuration load:** `train.py` reads the YAML file supplied via `--config` and passes it to `SRGAN_model`.【F:train.py†L19-L47】
-2. **Dataset selection:** `select_dataset` constructs train/validation datasets and wraps them into a Lightning `DataModule`. Dataset statistics are printed for sanity. 【F:data/data_utils.py†L1-L95】【F:data/data_utils.py†L121-L140】
-3. **Logger setup:** Weights & Biases, TensorBoard, and a learning-rate monitor are initialised. Checkpoints are saved under `logs/<project>/<timestamp>/`.【F:train.py†L59-L93】
-4. **Training loop:** `Trainer.fit` launches GPU-accelerated training with callbacks for checkpointing, early stopping, and LR monitoring. 【F:train.py†L69-L96】
+1. **Configuration load:** `train.py` reads the YAML file supplied via `--config` and passes it to `SRGAN_model`.
+2. **Dataset selection:** `select_dataset` constructs train/validation datasets and wraps them into a Lightning `DataModule`. Dataset statistics are printed for sanity.
+3. **Logger setup:** Weights & Biases, TensorBoard, and a learning-rate monitor are initialised. Checkpoints are saved under `logs/<project>/<timestamp>/`.
+4. **Training loop:** `Trainer.fit` launches GPU-accelerated training with callbacks for checkpointing, early stopping, and LR monitoring.
+
+```python
+--8<-- "../train.py:lines=19-113"
+```
+
+```python
+--8<-- "../data/data_utils.py:lines=1-150"
+```
 
 ## Lightning hooks inside `SRGAN_model`
 
 * `training_step`: Receives both generator and discriminator optimisers (Lightning’s GAN pattern). Handles generator-only pretraining, adversarial ramp-up, and logging of scalar losses/metrics.
 * `validation_step`: Generates super-resolved outputs for qualitative logging, computes metrics (PSNR, SSIM, LPIPS if configured), and stores them for epoch-level aggregation.
-* `configure_optimizers`: Creates two Adam optimisers plus `ReduceLROnPlateau` schedulers based on config values. 【F:model/SRGAN.py†L5-L12】
-* `on_validation_epoch_end`: Uses `utils.logging_helpers.plot_tensors` to push LR/SR/HR panels to TensorBoard and Weights & Biases. 【F:model/SRGAN.py†L12-L16】【F:utils/logging_helpers.py†L1-L200】
+* `configure_optimizers`: Creates two Adam optimisers plus `ReduceLROnPlateau` schedulers based on config values.
+* `on_validation_epoch_end`: Uses `utils.logging_helpers.plot_tensors` to push LR/SR/HR panels to TensorBoard and Weights & Biases.
+
+```python
+--8<-- "../model/SRGAN.py:lines=195-443"
+```
+
+```python
+--8<-- "../utils/logging_helpers.py:lines=1-72"
+```
 
 Inspect `model/SRGAN.py` for detailed comments describing each step of the training loop and logging behaviour.
 
@@ -24,26 +40,42 @@ Inspect `model/SRGAN.py` for detailed comments describing each step of the train
 
 | Callback | Purpose |
 |----------|---------|
-| `ModelCheckpoint` | Saves `last.ckpt` and top-2 checkpoints based on `Schedulers.metric` (default: `val_metrics/l1`).【F:train.py†L69-L93】|
-| `LearningRateMonitor` | Logs generator/discriminator learning rates each epoch to W&B/TensorBoard.【F:train.py†L88-L93】|
-| `EarlyStopping` | Monitors the same validation metric with large patience (250 epochs) to guard against divergence. 【F:train.py†L80-L88】|
+| `ModelCheckpoint` | Saves `last.ckpt` and top-2 checkpoints based on `Schedulers.metric` (default: `val_metrics/l1`).|
+| `LearningRateMonitor` | Logs generator/discriminator learning rates each epoch to W&B/TensorBoard.|
+| `EarlyStopping` | Monitors the same validation metric with large patience (250 epochs) to guard against divergence.|
 
-Weights & Biases is configured with `project="SRGAN_6bands"` and entity `opensr`. Set the `WANDB_PROJECT` or edit the script if you need per-experiment projects. TensorBoard logs are stored in `logs/` alongside W&B run data.【F:train.py†L59-L93】
+```python
+--8<-- "../train.py:lines=59-110"
+```
+
+Weights & Biases is configured with `project="SRGAN_6bands"` and entity `opensr`. Set the `WANDB_PROJECT` or edit the script if you need per-experiment projects. TensorBoard logs are stored in `logs/` alongside W&B run data.
 
 ## Adversarial training schedule
 
 GAN training is stabilised through three mechanisms:
 
-* **Generator pretraining:** For the first `Training.g_pretrain_steps`, only the generator optimiser runs; the discriminator is skipped. This lets the generator learn a strong content prior before adversarial updates start.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L52】
-* **Adversarial ramp-up:** After pretraining, the adversarial loss weight increases linearly or sigmoidally over `Training.adv_loss_ramp_steps` until it reaches `Losses.adv_loss_beta`.【F:model/SRGAN.py†L34-L43】【F:configs/config_10m.yaml†L35-L70】
-* **Label smoothing:** When `Training.label_smoothing=True`, real labels are reduced to 0.9 to prevent discriminator overconfidence.【F:model/SRGAN.py†L34-L43】
+* **Generator pretraining:** For the first `Training.g_pretrain_steps`, only the generator optimiser runs; the discriminator is skipped. This lets the generator learn a strong content prior before adversarial updates start.
+* **Adversarial ramp-up:** After pretraining, the adversarial loss weight increases linearly or sigmoidally over `Training.adv_loss_ramp_steps` until it reaches `Losses.adv_loss_beta`.
+* **Label smoothing:** When `Training.label_smoothing=True`, real labels are reduced to 0.9 to prevent discriminator overconfidence.
+
+```python
+--8<-- "../model/SRGAN.py:lines=34-58"
+```
+
+```yaml
+--8<-- "../configs/config_10m.yaml:lines=35-70"
+```
 
 These heuristics reduce mode collapse and stabilise training on multi-spectral inputs where illumination and texture vary drastically between bands.
 
 ## Practical tips
 
 * Monitor PSNR/SSIM/LPIPS in W&B to detect spectral artefacts early. If LPIPS diverges while PSNR improves, consider increasing `Losses.perceptual_weight`.
-* Use moderate `train_batch_size` values (8–16) to balance GPU utilisation and dataset variety. Increase `Data.prefetch_factor` when `num_workers > 0` to keep GPUs busy.【F:data/data_utils.py†L97-L140】
+* Use moderate `train_batch_size` values (8–16) to balance GPU utilisation and dataset variety. Increase `Data.prefetch_factor` when `num_workers > 0` to keep GPUs busy.
+
+```python
+--8<-- "../data/data_utils.py:lines=97-150"
+```
 * To benchmark architectures quickly, reuse trained generators by setting `Model.load_checkpoint` and adjusting only the discriminator or loss weights.
 * Keep an eye on GPU memory when scaling `Generator.n_blocks` and `n_channels`; RRDB and LKA variants are heavier than SRResNet.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ markdown_extensions:
       permalink: true
   - pymdownx.details
   - pymdownx.highlight
+  - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true


### PR DESCRIPTION
## Summary
- enable the `pymdownx.snippets` markdown extension for the MkDocs site
- replace manual inline citations in the documentation with live code snippets pulled from the source files
- update the guides to showcase generator, training, data, and logging internals directly from the codebase

## Testing
- mkdocs build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed159098088327bf8c6155e04c7615