### PR TITLE
Fix MkDocs snippets to reference repository sources

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ The central `SRGAN_model` class orchestrates the entire training loop.
 Configuration values are loaded through OmegaConf, losses are configured, and a model summary is printed for quick inspection.
 
 ```python
---8<-- "model/SRGAN.py:lines=25-71"
+--8<-- "../model/SRGAN.py:lines=25-71"
 ```
 
 ### Model wiring
@@ -19,7 +19,7 @@ Configuration values are loaded through OmegaConf, losses are configured, and a 
 `get_models()` attaches the generator and discriminator variants requested in the YAML configuration.
 
 ```python
---8<-- "model/SRGAN.py:lines=72-150"
+--8<-- "../model/SRGAN.py:lines=72-150"
 ```
 
 ### Inference helpers
@@ -27,7 +27,7 @@ Configuration values are loaded through OmegaConf, losses are configured, and a 
 `forward` and `predict_step` wrap generator inference with automatic normalisation and histogram matching so predictions align with Sentinel-2 statistics.
 
 ```python
---8<-- "model/SRGAN.py:lines=151-192"
+--8<-- "../model/SRGAN.py:lines=151-192"
 ```
 
 ### Training hooks
@@ -35,7 +35,7 @@ Configuration values are loaded through OmegaConf, losses are configured, and a 
 Lightning hooks drive generator-only pretraining, adversarial ramp-up, and detailed metric logging.
 
 ```python
---8<-- "model/SRGAN.py:lines=195-320"
+--8<-- "../model/SRGAN.py:lines=195-320"
 ```
 
 ## Generator zoo
@@ -54,23 +54,23 @@ Pick the generator backbone by setting `Generator.model_type` in the config. The
 Each generator consumes `Model.in_bands` channels, expands to `Generator.n_channels` features, and upsamples by `Generator.scaling_factor` using pixel shuffle stages. Kernel sizes (`large_kernel_size`, `small_kernel_size`) tailor the receptive field for remote-sensing textures.
 
 ```python
---8<-- "model/SRGAN.py:lines=82-118"
+--8<-- "../model/SRGAN.py:lines=82-118"
 ```
 
 ```python
---8<-- "model/generators/flexible_generator.py:lines=1-96"
+--8<-- "../model/generators/flexible_generator.py:lines=1-96"
 ```
 
 Specialised blocks (RRDB, RCAB, large-kernel attention) are registered in `model/model_blocks` and consumed by the flexible generator.
 
 ```python
---8<-- "model/model_blocks/__init__.py:lines=144-249"
+--8<-- "../model/model_blocks/__init__.py:lines=144-249"
 ```
 
 Conditional GAN support routes through the dedicated generator class, which injects noise vectors and optional conditional embeddings.
 
 ```python
---8<-- "model/generators/cgan_generator.py:lines=15-137"
+--8<-- "../model/generators/cgan_generator.py:lines=15-137"
 ```
 
 ## Discriminators
@@ -78,13 +78,13 @@ Conditional GAN support routes through the dedicated generator class, which inje
 Discriminator selection lives under `Discriminator.model_type`. The Lightning module wires either the standard SRGAN CNN or a PatchGAN variant and forwards multi-band inputs without assuming RGB ordering.
 
 ```python
---8<-- "model/SRGAN.py:lines=102-150"
+--8<-- "../model/SRGAN.py:lines=102-150"
 ```
 
 The PatchGAN implementation and supporting building blocks live under `model/descriminators/`.
 
 ```python
---8<-- "model/descriminators/srgan_discriminator.py:lines=1-71"
+--8<-- "../model/descriminators/srgan_discriminator.py:lines=1-71"
 ```
 
 Because both discriminators receive multi-band inputs, the repo avoids hard-coding RGB assumptions and allows training on arbitrary spectral stacks.
@@ -94,19 +94,19 @@ Because both discriminators receive multi-band inputs, the repo avoids hard-codi
 Generator training minimises a combination of content and adversarial losses. The Lightning module instantiates both criteria and scales them according to the YAML configuration.
 
 ```python
---8<-- "model/SRGAN.py:lines=34-64"
+--8<-- "../model/SRGAN.py:lines=34-64"
 ```
 
 `GeneratorContentLoss` mixes L1, spectral angle mapper, perceptual metrics, and total variation into a single callable.
 
 ```python
---8<-- "model/loss/loss.py:lines=1-210"
+--8<-- "../model/loss/loss.py:lines=1-210"
 ```
 
 Training warm-ups and adversarial ramp schedules are defined directly in the configuration.
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=35-70"
+--8<-- "../configs/config_10m.yaml:lines=35-70"
 ```
 
 ## Normalisation and inference helpers
@@ -114,11 +114,11 @@ Training warm-ups and adversarial ramp schedules are defined directly in the con
 Remote-sensing imagery often arrives as 0–10,000 scaled reflectance. `utils.spectral_helpers` provides `normalise_10k` for scaling to 0–1 and `histogram` for histogram matching. `predict_step` calls both utilities to ensure outputs match the statistical distribution of inputs before returning CPU tensors.
 
 ```python
---8<-- "model/SRGAN.py:lines=160-192"
+--8<-- "../model/SRGAN.py:lines=160-192"
 ```
 
 ```python
---8<-- "utils/spectral_helpers.py:lines=53-200"
+--8<-- "../utils/spectral_helpers.py:lines=53-200"
 ```
 
 ## Logging utilities
@@ -126,11 +126,11 @@ Remote-sensing imagery often arrives as 0–10,000 scaled reflectance. `utils.sp
 Qualitative logging is handled via `utils.logging_helpers.plot_tensors`, which renders low-/super-/high-resolution panels for TensorBoard and Weights & Biases. The Lightning module invokes these helpers inside validation hooks so you can monitor spectral fidelity and artefacts during training.
 
 ```python
---8<-- "model/SRGAN.py:lines=12-16"
+--8<-- "../model/SRGAN.py:lines=12-16"
 ```
 
 ```python
---8<-- "utils/logging_helpers.py:lines=1-72"
+--8<-- "../utils/logging_helpers.py:lines=1-72"
 ```
 
 ## Extending the model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ Remote-Sensing-SRGAN is intentionally configuration-first. Every YAML file under
 Each config follows the same structure as `configs/config_10m.yaml`:
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=12-132"
+--8<-- "../configs/config_10m.yaml:lines=12-132"
 ```
 
 ## Data block
@@ -15,7 +15,7 @@ Each config follows the same structure as `configs/config_10m.yaml`:
 The data section controls loader throughput and selects the dataset implementation. The `dataset_type` key is forwarded to `data.data_utils.select_dataset`, which instantiates the proper dataset class and wraps it into a Lightning `DataModule` with the requested batch sizes and worker settings.
 
 ```python
---8<-- "data/data_utils.py:lines=1-150"
+--8<-- "../data/data_utils.py:lines=1-150"
 ```
 
 ### Available dataset types
@@ -37,11 +37,11 @@ The `Model` section captures properties that affect both training and checkpoint
 * `continue_training`: checkpoint to resume including optimiser states and scheduler counters (mapped to `Trainer(resume_from_checkpoint=...)`).
 
 ```python
---8<-- "model/SRGAN.py:lines=62-118"
+--8<-- "../model/SRGAN.py:lines=62-118"
 ```
 
 ```python
---8<-- "train.py:lines=34-48"
+--8<-- "../train.py:lines=34-48"
 ```
 
 ## Training block
@@ -54,17 +54,17 @@ Training-related switches are consumed inside the Lightning module:
 * `label_smoothing`: enables 0.9 real labels in the discriminator to reduce overconfidence.
 
 ```python
---8<-- "model/SRGAN.py:lines=34-58"
+--8<-- "../model/SRGAN.py:lines=34-58"
 ```
 
 The nested `Losses` dictionary is passed to `GeneratorContentLoss`, which mixes pixel-space (`l1_weight`), spectral (`sam_weight`), perceptual (`perceptual_weight` with `perceptual_metric`), and total-variation (`tv_weight`) losses. The final adversarial weight after ramp-up is `adv_loss_beta`.
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=35-70"
+--8<-- "../configs/config_10m.yaml:lines=35-70"
 ```
 
 ```python
---8<-- "model/loss/loss.py:lines=1-210"
+--8<-- "../model/loss/loss.py:lines=1-210"
 ```
 
 ## Generator and Discriminator blocks
@@ -77,13 +77,13 @@ Generator parameters control the backbone constructed in `SRGAN_model.get_models
 * `large_kernel_size`, `small_kernel_size`: head/tail and residual block kernel sizes to shape receptive field.
 
 ```python
---8<-- "model/SRGAN.py:lines=72-150"
+--8<-- "../model/SRGAN.py:lines=72-150"
 ```
 
 The discriminator section selects either the classic SRGAN CNN (`standard`) or a PatchGAN variant and optionally specifies convolutional depth via `n_blocks`.
 
 ```python
---8<-- "model/descriminators/srgan_discriminator.py:lines=1-71"
+--8<-- "../model/descriminators/srgan_discriminator.py:lines=1-71"
 ```
 
 ## Optimisers and schedulers
@@ -91,11 +91,11 @@ The discriminator section selects either the classic SRGAN CNN (`standard`) or a
 Both the generator and discriminator use Adam optimisers with learning rates read from `Optimizers.optim_g_lr` and `Optimizers.optim_d_lr`. The Lightning module instantiates `ReduceLROnPlateau` schedulers using the parameters provided under `Schedulers` (`metric`, `patience_*`, `factor_*`, `verbose`).
 
 ```python
---8<-- "model/SRGAN.py:lines=408-443"
+--8<-- "../model/SRGAN.py:lines=408-443"
 ```
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=103-132"
+--8<-- "../configs/config_10m.yaml:lines=103-132"
 ```
 
 ## Logging
@@ -103,11 +103,11 @@ Both the generator and discriminator use Adam optimisers with learning rates rea
 The `Logging` section controls qualitative outputs. During validation the model logs `num_val_images` panels via TensorBoard and Weights & Biases. The training script also wires in Weights & Biases, TensorBoard, and learning-rate monitors; edit this block if you want fewer images per epoch.
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=128-132"
+--8<-- "../configs/config_10m.yaml:lines=128-132"
 ```
 
 ```python
---8<-- "train.py:lines=59-93"
+--8<-- "../train.py:lines=59-93"
 ```
 
 ## Tips for custom configs

--- a/docs/data.md
+++ b/docs/data.md
@@ -7,7 +7,7 @@ Remote-Sensing-SRGAN ships with dataset loaders tailored to Sentinel-2 SAFE prod
 `data.data_utils.select_dataset(config)` reads `config.Data.dataset_type` and constructs the appropriate dataset instances. The helper then wraps them into a minimal Lightning `DataModule` with configurable batch sizes, worker counts, and prefetch factors.
 
 ```python
---8<-- "data/data_utils.py:lines=1-150"
+--8<-- "../data/data_utils.py:lines=1-150"
 ```
 
 ```python
@@ -24,7 +24,7 @@ The selector currently supports three dataset families:
 * **Implementation:** Uses `data/SEN2_SAFE/S2_6b_ds.py::S2SAFEDataset` to read a manifest of pre-windowed chips. The dataset handles normalisation, band ordering, LR synthesis via anti-aliased downsampling, and invalid chip filtering.
 
 ```python
---8<-- "data/data_utils.py:lines=17-48"
+--8<-- "../data/data_utils.py:lines=17-48"
 ```
 * **Configuration hooks:** `Generator.scaling_factor` determines the SR scale (2×/4×/8×). Hard-coded manifest path and band order can be promoted to config keys if you need to vary them frequently.
 
@@ -34,7 +34,7 @@ The selector currently supports three dataset families:
 * **Implementation:** Reuses `S2SAFEDataset` with an alternative band list. Despite the 10 m intent, the manifest path currently points to the 20 m JSON; adjust it if you curate a dedicated 10 m manifest.
 
 ```python
---8<-- "data/data_utils.py:lines=50-82"
+--8<-- "../data/data_utils.py:lines=50-82"
 ```
 * **Configuration hooks:** Same as `S2_6b`; update band order and manifest in the dataset branch if you require different inputs.
 
@@ -44,7 +44,7 @@ The selector currently supports three dataset families:
 * **Implementation:** The `SISRWorldWide` dataset (under `data/SISR_WW/`) reads the dataset root, honours `split` arguments (`train`/`val`), and returns aligned `(lr, hr)` samples. The data selector simply instantiates train/val splits pointing to `/data3/SEN2NAIP_global` by default.
 
 ```python
---8<-- "data/data_utils.py:lines=84-95"
+--8<-- "../data/data_utils.py:lines=84-95"
 ```
 * **Configuration hooks:** Update the root path or expose it through the config to point at your local dataset copy.
 
@@ -57,7 +57,7 @@ Adding a dataset follows three simple steps:
 3. **Expose configuration keys** under `Data` (e.g., `manifest_path`, `bands_keep`) so experiments remain reproducible without code edits.
 
 ```python
---8<-- "data/data_utils.py:lines=1-95"
+--8<-- "../data/data_utils.py:lines=1-95"
 ```
 
 ## DataLoader configuration
@@ -70,7 +70,7 @@ Adding a dataset follows three simple steps:
 * `shuffle`: enabled for both train and validation to improve spatial diversity in evaluation batches (intentional design choice).
 
 ```python
---8<-- "data/data_utils.py:lines=97-150"
+--8<-- "../data/data_utils.py:lines=97-150"
 ```
 
 Because the `DataModule` is assembled dynamically, you can plug in custom datasets without changing the training loop — just add a branch and update your YAML.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,13 +7,13 @@ This guide walks through environment setup, configuration management, and the mi
 The project pins PyTorch 1.13 and torchvision 0.14 wheels that target Python 3.10. Set up your environment with that interpreter and install dependencies before launching training.
 
 ```markdown
---8<-- "README.md:lines=52-83"
+--8<-- "../README.md:lines=52-83"
 ```
 
 The default trainer is configured for CUDA acceleration and streams metrics to both TensorBoard and Weights & Biases.
 
 ```python
---8<-- "train.py:lines=69-110"
+--8<-- "../train.py:lines=69-110"
 ```
 
 Create a Weights & Biases account if you plan to use the built-in experiment tracking, and install Git LFS when working with large dataset manifests.
@@ -47,7 +47,7 @@ pip install torch==1.13.1 torchvision==0.14.1 --index-url https://download.pytor
 All experiment settings live in YAML files under `configs/`. The `config_20m.yaml` template targets Sentinel-2 20 m inputs, while `config_10m.yaml` demonstrates 10 m multi-band training. Each section controls loaders, models, training schedules, and logging behaviour.
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=12-132"
+--8<-- "../configs/config_10m.yaml:lines=12-132"
 ```
 
 Duplicate a config file if you need to adjust parameters without touching the defaults:
@@ -67,7 +67,7 @@ python train.py --config configs/my_experiment.yaml
 Under the hood the script loads the YAML, constructs datasets, wires loggers and callbacks, and launches GPU-accelerated training with Lightning.
 
 ```python
---8<-- "train.py:lines=19-113"
+--8<-- "../train.py:lines=19-113"
 ```
 
 Training logs, checkpoints, and exported validation panels are written into `logs/` alongside the W&B run.
@@ -77,7 +77,7 @@ Training logs, checkpoints, and exported validation panels are written into `log
 Two checkpoint switches let you reuse trained weights without editing Python code:
 
 ```python
---8<-- "train.py:lines=34-48"
+--8<-- "../train.py:lines=34-48"
 ```
 
 ## Inference quick peek
@@ -85,7 +85,7 @@ Two checkpoint switches let you reuse trained weights without editing Python cod
 For offline inference, instantiate `SRGAN_model` and call `predict_step` with low-resolution tensors. The method auto-normalises Sentinel-2 style inputs, runs the generator, histogram matches the output, and denormalises back to the original range.
 
 ```python
---8<-- "model/SRGAN.py:lines=153-192"
+--8<-- "../model/SRGAN.py:lines=153-192"
 ```
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Remote-Sensing-SRGAN is a research-grade training stack for single-image super-r
 Choose between SRResNet, residual, RCAB, RRDB, large-kernel attention, or conditional GAN backbones with scale factors from 2×–8×.
 
 ```python
---8<-- "model/SRGAN.py:lines=72-118"
+--8<-- "../model/SRGAN.py:lines=72-118"
 ```
 
 ### Pluggable losses
@@ -20,11 +20,11 @@ Choose between SRResNet, residual, RCAB, RRDB, large-kernel attention, or condit
 Pixel, spectral, perceptual, adversarial, and total-variation terms can be mixed with independent weights and activation schedules.
 
 ```python
---8<-- "model/SRGAN.py:lines=34-58"
+--8<-- "../model/SRGAN.py:lines=34-58"
 ```
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=35-70"
+--8<-- "../configs/config_10m.yaml:lines=35-70"
 ```
 
 ### Remote-sensing ready datasets
@@ -32,7 +32,7 @@ Pixel, spectral, perceptual, adversarial, and total-variation terms can be mixed
 Sentinel-2 SAFE windowing and the SEN2NAIP worldwide pairs are built in, with Lightning datamodules created on the fly from the configuration.
 
 ```python
---8<-- "data/data_utils.py:lines=1-95"
+--8<-- "../data/data_utils.py:lines=1-95"
 ```
 
 ### Stabilised training flow
@@ -40,7 +40,7 @@ Sentinel-2 SAFE windowing and the SEN2NAIP worldwide pairs are built in, with Li
 Generator-only warm-up, adversarial ramp-up, discriminator scheduling, and Lightning callbacks are wired into the training script.
 
 ```python
---8<-- "train.py:lines=19-93"
+--8<-- "../train.py:lines=19-93"
 ```
 
 ### Comprehensive logging
@@ -48,11 +48,11 @@ Generator-only warm-up, adversarial ramp-up, discriminator scheduling, and Light
 TensorBoard visualisations, Weights & Biases tracking, and qualitative inspection panels are emitted during training.
 
 ```python
---8<-- "model/SRGAN.py:lines=12-16"
+--8<-- "../model/SRGAN.py:lines=12-16"
 ```
 
 ```python
---8<-- "train.py:lines=59-93"
+--8<-- "../train.py:lines=59-93"
 ```
 
 ## Repository layout

--- a/docs/training.md
+++ b/docs/training.md
@@ -10,11 +10,11 @@ Remote-Sensing-SRGAN uses PyTorch Lightning to manage training loops, logging, a
 4. **Training loop:** `Trainer.fit` launches GPU-accelerated training with callbacks for checkpointing, early stopping, and LR monitoring.
 
 ```python
---8<-- "train.py:lines=19-113"
+--8<-- "../train.py:lines=19-113"
 ```
 
 ```python
---8<-- "data/data_utils.py:lines=1-150"
+--8<-- "../data/data_utils.py:lines=1-150"
 ```
 
 ## Lightning hooks inside `SRGAN_model`
@@ -25,11 +25,11 @@ Remote-Sensing-SRGAN uses PyTorch Lightning to manage training loops, logging, a
 * `on_validation_epoch_end`: Uses `utils.logging_helpers.plot_tensors` to push LR/SR/HR panels to TensorBoard and Weights & Biases.
 
 ```python
---8<-- "model/SRGAN.py:lines=195-443"
+--8<-- "../model/SRGAN.py:lines=195-443"
 ```
 
 ```python
---8<-- "utils/logging_helpers.py:lines=1-72"
+--8<-- "../utils/logging_helpers.py:lines=1-72"
 ```
 
 Inspect `model/SRGAN.py` for detailed comments describing each step of the training loop and logging behaviour.
@@ -45,7 +45,7 @@ Inspect `model/SRGAN.py` for detailed comments describing each step of the train
 | `EarlyStopping` | Monitors the same validation metric with large patience (250 epochs) to guard against divergence.|
 
 ```python
---8<-- "train.py:lines=59-110"
+--8<-- "../train.py:lines=59-110"
 ```
 
 Weights & Biases is configured with `project="SRGAN_6bands"` and entity `opensr`. Set the `WANDB_PROJECT` or edit the script if you need per-experiment projects. TensorBoard logs are stored in `logs/` alongside W&B run data.
@@ -59,11 +59,11 @@ GAN training is stabilised through three mechanisms:
 * **Label smoothing:** When `Training.label_smoothing=True`, real labels are reduced to 0.9 to prevent discriminator overconfidence.
 
 ```python
---8<-- "model/SRGAN.py:lines=34-58"
+--8<-- "../model/SRGAN.py:lines=34-58"
 ```
 
 ```yaml
---8<-- "configs/config_10m.yaml:lines=35-70"
+--8<-- "../configs/config_10m.yaml:lines=35-70"
 ```
 
 These heuristics reduce mode collapse and stabilise training on multi-spectral inputs where illumination and texture vary drastically between bands.
@@ -74,7 +74,7 @@ These heuristics reduce mode collapse and stabilise training on multi-spectral i
 * Use moderate `train_batch_size` values (8–16) to balance GPU utilisation and dataset variety. Increase `Data.prefetch_factor` when `num_workers > 0` to keep GPUs busy.
 
 ```python
---8<-- "data/data_utils.py:lines=97-150"
+--8<-- "../data/data_utils.py:lines=97-150"
 ```
 * To benchmark architectures quickly, reuse trained generators by setting `Model.load_checkpoint` and adjusting only the discriminator or loss weights.
 * Keep an eye on GPU memory when scaling `Generator.n_blocks` and `n_channels`; RRDB and LKA variants are heavier than SRResNet.


### PR DESCRIPTION
## Summary
- prefix all MkDocs snippet includes with `../` so they resolve files from the repository root
- ensure documentation code blocks load correctly when building from CI or local environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed23d0dce483279ae611c67084edfb