### PR TITLE
Add EMA tracking for SRGAN generator

### DIFF
--- a/configs/config_10m.yaml
+++ b/configs/config_10m.yaml
@@ -46,6 +46,13 @@ Training:
   adv_loss_ramp_steps: 2500   # Gradual adversarial weight ramp steps
   label_smoothing: True        # Discriminator target smoothing (1.0 → 0.9)
 
+  EMA:
+    enabled: False             # Maintain exponential moving average of generator weights
+    decay: 0.999               # EMA decay factor (closer to 1.0 → smoother updates)
+    update_after_step: 0       # Delay EMA updates until this global step (0 = immediate)
+    device: null               # Store EMA weights on a specific device (e.g. "cpu"), null → follow model
+    use_num_updates: True      # Use adaptive decay warmup based on number of updates
+
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up

--- a/configs/config_20m.yaml
+++ b/configs/config_20m.yaml
@@ -46,6 +46,13 @@ Training:
   adv_loss_ramp_steps: 5000   # Gradual adversarial weight ramp steps
   label_smoothing: True        # Discriminator target smoothing (1.0 → 0.9)
 
+  EMA:
+    enabled: False             # Maintain exponential moving average of generator weights
+    decay: 0.999               # EMA decay factor (closer to 1.0 → smoother updates)
+    update_after_step: 0       # Delay EMA updates until this global step (0 = immediate)
+    device: null               # Store EMA weights on a specific device (e.g. "cpu"), null → follow model
+    use_num_updates: True      # Use adaptive decay warmup based on number of updates
+
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up

--- a/model/SRGAN.py
+++ b/model/SRGAN.py
@@ -1,5 +1,6 @@
 # Package Imports
 import math
+from contextlib import nullcontext
 
 import torch
 from torch.optim.lr_scheduler import ReduceLROnPlateau
@@ -14,6 +15,7 @@ from utils.logging_helpers import plot_tensors
 from utils.spectral_helpers import normalise_10k
 from utils.spectral_helpers import histogram as histogram_match
 from utils.model_descriptions import print_model_summary
+from model.model_blocks import ExponentialMovingAverage
 
 
 #############################################################################################################
@@ -54,6 +56,23 @@ class SRGAN_model(pl.LightningModule):
         # Purpose: Build generator network depending on selected architecture.
         # ======================================================================
         self.get_models()  # dynamically builds and attaches generator + discriminator
+
+        # Optional exponential moving average (EMA) tracking for generator weights
+        ema_cfg = getattr(self.config.Training, "EMA", None)
+        self.ema: ExponentialMovingAverage | None = None
+        self._ema_update_after_step = 0
+        self._ema_applied = False
+        if ema_cfg is not None and getattr(ema_cfg, "enabled", False):
+            ema_decay = float(getattr(ema_cfg, "decay", 0.999))
+            ema_device = getattr(ema_cfg, "device", None)
+            use_num_updates = bool(getattr(ema_cfg, "use_num_updates", True))
+            self.ema = ExponentialMovingAverage(
+                self.generator,
+                decay=ema_decay,
+                use_num_updates=use_num_updates,
+                device=ema_device,
+            )
+            self._ema_update_after_step = int(getattr(ema_cfg, "update_after_step", 0))
 
         # ======================================================================
         # SECTION: Define Loss Functions
@@ -171,8 +190,10 @@ class SRGAN_model(pl.LightningModule):
         else:
             normalized = False                                       # already normalized
 
-        # --- Perform super-resolution ---
-        sr_imgs = self.generator(lr_imgs)                            # forward pass (SR prediction)
+        # --- Perform super-resolution (optionally using EMA weights) ---
+        context = self.ema.average_parameters(self.generator) if self.ema is not None else nullcontext()
+        with context:
+            sr_imgs = self.generator(lr_imgs)                        # forward pass (SR prediction)
 
         # --- Histogram match SR to LR ---
         sr_imgs = histogram_match(lr_imgs, sr_imgs)                  # match distributions
@@ -254,7 +275,7 @@ class SRGAN_model(pl.LightningModule):
 
         # -------- Normal Train: Generator Step  --------
         if optimizer_idx==1:
-            
+
             """ 1. Get VGG space loss """
             # encode images
             content_loss, metrics = self.content_loss_criterion.return_loss(sr_imgs, hr_imgs)   # perceptual/content criterion (e.g., VGG)
@@ -262,12 +283,12 @@ class SRGAN_model(pl.LightningModule):
             for key, value in metrics.items():
                 self.log(f"train_metrics/{key}", value)                             # log detailed metrics without extra forward passes
 
-            
+
             """ 2. Get Discriminator Opinion and loss """
             # run discriminator and get loss between pred labels and true labels
             sr_discriminated = self.discriminator(sr_imgs)                             # D(SR): logits for generator outputs
             adversarial_loss = self.adversarial_loss_criterion(sr_discriminated, torch.ones_like(sr_discriminated)) # keep taargets 1.0 for G loss
-            
+
             """ 3. Weight the losses"""
             adv_weight = self._adv_loss_weight() # get adversarial weight based on current step
             adversarial_loss_weighted = (adversarial_loss * adv_weight) # weight adversarial loss
@@ -276,6 +297,26 @@ class SRGAN_model(pl.LightningModule):
 
             # return Generator loss
             return total_loss                                                         # PL will use this to step the G optimizer
+
+    def optimizer_step(
+        self,
+        epoch,
+        batch_idx,
+        optimizer,
+        optimizer_idx,
+        optimizer_closure,
+        on_tpu=False,
+        using_lbfgs=False,
+    ):
+        optimizer.step(closure=optimizer_closure)
+        optimizer.zero_grad()
+
+        if (
+            self.ema is not None
+            and optimizer_idx == 1
+            and self.global_step >= self._ema_update_after_step
+        ):
+            self.ema.update(self.generator)
 
     def pretraining_training_step(self, *, lr_imgs, hr_imgs, sr_imgs, optimizer_idx):
         """
@@ -396,8 +437,21 @@ class SRGAN_model(pl.LightningModule):
                 self.log("validation/DISC_adversarial_loss",adversarial_loss)
 
 
+    def on_validation_epoch_start(self):
+        super().on_validation_epoch_start()
+        self._apply_generator_ema_weights()
+
     def on_validation_epoch_end(self):
-        pass
+        self._restore_generator_weights()
+        super().on_validation_epoch_end()
+
+    def on_test_epoch_start(self):
+        super().on_test_epoch_start()
+        self._apply_generator_ema_weights()
+
+    def on_test_epoch_end(self):
+        self._restore_generator_weights()
+        super().on_test_epoch_end()
 
     def configure_optimizers(self):
 
@@ -481,11 +535,15 @@ class SRGAN_model(pl.LightningModule):
         self._log_lrs() # log LR's on each batch end
 
     def on_fit_start(self):  # called once at the start of training
+        super().on_fit_start()
         # ======================================================================
         # SECTION: Print Model Summary
         # Purpose: Output model architecture and parameter counts.
         # ======================================================================
         print_model_summary(self)  # print model summary to console
+
+        if self.ema is not None and self.ema.device is None:
+            self.ema.to(self.device)
 
     def _log_generator_content_loss(self, content_loss: torch.Tensor) -> None:
         """Helper to consistently log the generator content loss across training phases."""
@@ -549,8 +607,32 @@ class SRGAN_model(pl.LightningModule):
     def _adv_loss_weight(self):
         adv_weight = self._compute_adv_loss_weight()
         self._log_adv_loss_weight(adv_weight)
-        return adv_weight                         
-    
+        return adv_weight
+
+    def _apply_generator_ema_weights(self) -> None:
+        if self.ema is None or self._ema_applied:
+            return
+        if self.ema.device is None:
+            self.ema.to(self.device)
+        self.ema.apply_to(self.generator)
+        self._ema_applied = True
+
+    def _restore_generator_weights(self) -> None:
+        if self.ema is None or not self._ema_applied:
+            return
+        self.ema.restore(self.generator)
+        self._ema_applied = False
+
+    def on_save_checkpoint(self, checkpoint: dict) -> None:
+        super().on_save_checkpoint(checkpoint)
+        if self.ema is not None:
+            checkpoint["ema_state"] = self.ema.state_dict()
+
+    def on_load_checkpoint(self, checkpoint: dict) -> None:
+        super().on_load_checkpoint(checkpoint)
+        if self.ema is not None and "ema_state" in checkpoint:
+            self.ema.load_state_dict(checkpoint["ema_state"])
+
     def _log_lrs(self):
         # order matches your return: [optimizer_d, optimizer_g]
         opt_d = self.trainer.optimizers[0]

--- a/model/model_blocks/EMA.py
+++ b/model/model_blocks/EMA.py
@@ -1,0 +1,182 @@
+"""Exponential Moving Average (EMA) utilities for model parameter smoothing."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Dict, Iterator
+
+import torch
+from torch import nn
+
+
+class ExponentialMovingAverage:
+    """Maintain exponential moving averages of a model's parameters.
+
+    The implementation tracks trainable parameters as well as buffers (e.g.,
+    running statistics in batch-normalization layers) and provides helpers to
+    temporarily swap a model to the smoothed weights during evaluation.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        decay: float = 0.999,
+        *,
+        use_num_updates: bool = True,
+        device: str | torch.device | None = None,
+    ) -> None:
+        if not 0.0 <= decay <= 1.0:
+            raise ValueError("decay must be between 0 and 1 (inclusive)")
+
+        self.decay = float(decay)
+        self.num_updates = 0 if use_num_updates else None
+        self.device = torch.device(device) if device is not None else None
+
+        self.shadow_params: Dict[str, torch.Tensor] = {}
+        self.shadow_buffers: Dict[str, torch.Tensor] = {}
+        self.collected_params: Dict[str, torch.Tensor] = {}
+        self.collected_buffers: Dict[str, torch.Tensor] = {}
+
+        self._register(model)
+
+    def _register(self, model: nn.Module) -> None:
+        for name, param in model.named_parameters():
+            if not param.requires_grad:
+                continue
+            shadow = param.detach().clone()
+            if self.device is not None:
+                shadow = shadow.to(self.device)
+            self.shadow_params[name] = shadow
+
+        for name, buffer in model.named_buffers():
+            shadow = buffer.detach().clone()
+            if self.device is not None:
+                shadow = shadow.to(self.device)
+            self.shadow_buffers[name] = shadow
+
+    def update(self, model: nn.Module) -> None:
+        """Update EMA weights using parameters from ``model``."""
+
+        if self.num_updates is not None:
+            self.num_updates += 1
+            decay = min(self.decay, (1 + self.num_updates) / (10 + self.num_updates))
+        else:
+            decay = self.decay
+
+        one_minus_decay = 1.0 - decay
+
+        with torch.no_grad():
+            for name, param in model.named_parameters():
+                if not param.requires_grad:
+                    continue
+
+                if name not in self.shadow_params:
+                    # Parameter may have been added dynamically (rare, but safeguard)
+                    shadow = param.detach().clone()
+                    if self.device is not None:
+                        shadow = shadow.to(self.device)
+                    self.shadow_params[name] = shadow
+
+                shadow_param = self.shadow_params[name]
+                param_data = param.detach()
+                if param_data.device != shadow_param.device:
+                    param_data = param_data.to(shadow_param.device)
+
+                shadow_param.lerp_(param_data, one_minus_decay)
+
+            for name, buffer in model.named_buffers():
+                if name not in self.shadow_buffers:
+                    shadow = buffer.detach().clone()
+                    if self.device is not None:
+                        shadow = shadow.to(self.device)
+                    self.shadow_buffers[name] = shadow
+
+                shadow_buffer = self.shadow_buffers[name]
+                buffer_data = buffer.detach()
+                if buffer_data.device != shadow_buffer.device:
+                    buffer_data = buffer_data.to(shadow_buffer.device)
+                shadow_buffer.copy_(buffer_data)
+
+    def apply_to(self, model: nn.Module) -> None:
+        """Copy EMA parameters into ``model`` while backing up original values."""
+
+        if self.collected_params or self.collected_buffers:
+            raise RuntimeError("EMA weights already applied; call restore() before reapplying.")
+
+        for name, param in model.named_parameters():
+            if not param.requires_grad or name not in self.shadow_params:
+                continue
+            self.collected_params[name] = param.detach().clone()
+            param.data.copy_(self.shadow_params[name].to(param.device))
+
+        for name, buffer in model.named_buffers():
+            if name not in self.shadow_buffers:
+                continue
+            self.collected_buffers[name] = buffer.detach().clone()
+            buffer.data.copy_(self.shadow_buffers[name].to(buffer.device))
+
+    def restore(self, model: nn.Module) -> None:
+        """Restore original parameters that were swapped out via :meth:`apply_to`."""
+
+        for name, param in model.named_parameters():
+            cached = self.collected_params.pop(name, None)
+            if cached is None:
+                continue
+            param.data.copy_(cached.to(param.device))
+
+        for name, buffer in model.named_buffers():
+            cached = self.collected_buffers.pop(name, None)
+            if cached is None:
+                continue
+            buffer.data.copy_(cached.to(buffer.device))
+
+    @contextmanager
+    def average_parameters(self, model: nn.Module) -> Iterator[None]:
+        """Context manager that temporarily applies EMA weights to ``model``."""
+
+        self.apply_to(model)
+        try:
+            yield
+        finally:
+            self.restore(model)
+
+    def to(self, device: str | torch.device) -> None:
+        """Move EMA statistics to ``device``."""
+
+        target_device = torch.device(device)
+        for name, tensor in list(self.shadow_params.items()):
+            self.shadow_params[name] = tensor.to(target_device)
+        for name, tensor in list(self.shadow_buffers.items()):
+            self.shadow_buffers[name] = tensor.to(target_device)
+        self.device = target_device
+
+    def state_dict(self) -> Dict[str, object]:
+        """Return a serializable state dict for checkpointing."""
+
+        return {
+            "decay": self.decay,
+            "num_updates": self.num_updates,
+            "device": str(self.device) if self.device is not None else None,
+            "shadow_params": {k: v.detach().cpu() for k, v in self.shadow_params.items()},
+            "shadow_buffers": {k: v.detach().cpu() for k, v in self.shadow_buffers.items()},
+        }
+
+    def load_state_dict(self, state_dict: Dict[str, object]) -> None:
+        """Load EMA statistics from ``state_dict``."""
+
+        self.decay = float(state_dict["decay"])
+        self.num_updates = state_dict["num_updates"]
+        device_str = state_dict.get("device", None)
+        self.device = torch.device(device_str) if device_str is not None else None
+
+        self.shadow_params = {
+            name: tensor.clone().to(self.device) if self.device is not None else tensor.clone()
+            for name, tensor in state_dict.get("shadow_params", {}).items()
+        }
+        self.shadow_buffers = {
+            name: tensor.clone().to(self.device) if self.device is not None else tensor.clone()
+            for name, tensor in state_dict.get("shadow_buffers", {}).items()
+        }
+
+        self.collected_params = {}
+        self.collected_buffers = {}

--- a/model/model_blocks/__init__.py
+++ b/model/model_blocks/__init__.py
@@ -6,6 +6,8 @@ import math
 import torch
 from torch import nn
 
+from .EMA import ExponentialMovingAverage
+
 __all__ = [
     "ConvolutionalBlock",
     "SubPixelConvolutionalBlock",
@@ -17,6 +19,7 @@ __all__ = [
     "LKA",
     "LKAResBlock",
     "make_upsampler",
+    "ExponentialMovingAverage",
 ]
 
 


### PR DESCRIPTION
## Summary
- add configurable EMA options to the training YAML files
- implement a reusable ExponentialMovingAverage helper in the model blocks package
- integrate generator EMA updates, evaluation swaps, and checkpoint persistence into the SRGAN Lightning module

## Testing
- python -m compileall model

------
https://chatgpt.com/codex/tasks/task_e_68ee39e453948327b94efe0925d1f90b