### PR TITLE
Rename adversarial warmup schedule to cosine

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ All key knobs are exposed via YAML in the `configs` folder:
 ## 🎚️ Training Stabilization Strategies
 
 * **G‑only pretraining:** Train with content/perceptual losses while the adversarial term is held at zero during the first `g_pretrain_steps`.
-* **Adversarial ramp‑up:** Increase the BCE adversarial weight **linearly** or smoothly (**sigmoid**) over `adv_loss_ramp_steps` until it reaches `adv_loss_beta`.
+* **Adversarial ramp‑up:** Increase the BCE adversarial weight **linearly** or smoothly (**cosine**) over `adv_loss_ramp_steps` until it reaches `adv_loss_beta`.
 * **Generator LR warmup:** Ramp the generator optimiser with a **cosine** or **linear** schedule for the first 1–5k steps via `Schedulers.g_warmup_steps`/`g_warmup_type` before switching to plateau-based reductions.
 * **EMA smoothing:** Enable `Training.EMA.enabled` to keep a shadow copy of the generator. Decay values in the 0.995–0.9999 range balance responsiveness with stability and are swapped in automatically for validation/inference.
 

--- a/configs/config_10m.yaml
+++ b/configs/config_10m.yaml
@@ -55,7 +55,7 @@ Training:
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up
-    adv_loss_schedule: 'sigmoid'  # Adversarial weight ramp type: ['linear', 'sigmoid']
+    adv_loss_schedule: 'cosine'   # Adversarial weight ramp type: ['linear', 'cosine']
 
     # --- Content loss components (GeneratorContentLoss) ---
     l1_weight: 1.0             # L1 loss over all bands

--- a/configs/config_20m.yaml
+++ b/configs/config_20m.yaml
@@ -55,7 +55,7 @@ Training:
   Losses:
     # --- GAN term ---
     adv_loss_beta: 1e-3        # Final adversarial loss weight after ramp-up
-    adv_loss_schedule: 'sigmoid'  # Adversarial weight ramp type: ['linear', 'sigmoid']
+    adv_loss_schedule: 'cosine'   # Adversarial weight ramp type: ['linear', 'cosine']
 
     # --- Content loss components (GeneratorContentLoss) ---
     l1_weight: 1.0             # L1 loss over all bands

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ The module is initialised from a YAML configuration file and provides the follow
 | Method | Purpose |
 | --- | --- |
 | `_pretrain_check()` | Determines whether the generator-only warm-up is active. |
-| `_compute_adv_loss_weight()` | Produces the ramped adversarial weight using `linear` or `sigmoid` schedules. |
+| `_compute_adv_loss_weight()` | Produces the ramped adversarial weight using `linear` or `cosine` schedules. |
 | `_log_generator_content_loss()` and `_log_adv_loss_weight()` | Centralise logging so metrics remain consistent across phases. |
 | `on_fit_start()` | Prints informative status messages when training begins. |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ stable validation imagery. The EMA is fully optional and controlled through the 
 | Key | Default | Description |
 | --- | --- | --- |
 | `adv_loss_beta` | `1e-3` | Target weight applied to the adversarial term after ramp-up. |
-| `adv_loss_schedule` | `sigmoid` | Ramp shape (`linear` or `sigmoid`). |
+| `adv_loss_schedule` | `cosine` | Ramp shape (`linear` or `cosine`). |
 | `l1_weight` | `1.0` | Weight of the pixelwise L1 loss. |
 | `sam_weight` | `0.05` | Weight of the spectral angle mapper loss. |
 | `perceptual_weight` | `0.1` | Weight of the perceptual feature loss. |


### PR DESCRIPTION
## Summary
- align the adversarial warmup schedule option with the cosine generator warmup naming and behaviour
- update default configs and documentation to reflect the cosine ramp choice

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee5374912883279ce32db4270f4439