### PR TITLE
docs: document multi-GPU training workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository provides:
 * 🛰️ **Flexible inputs**: train on **any band layout** (e.g., S2 RGB‑NIR, 6‑band stacks, or custom multispectral sets). Normalization/denorm utilities provided.
 * ⚖️ **Flexible losses & weights**: combine L1, Spectral Angle Mapper, VGG19 or LPIPS perceptual distances, Total Variation, and a BCE adversarial term with **per‑loss weights**.
 * 🧪 **Robust training strategy**: generator **pretraining**, **linear adversarial loss ramp**, **cosine/linear LR warmup**, and **discriminator update schedules/curves**.
+* ⚡ **Multi-GPU acceleration**: run Lightning's DDP backend out of the box by listing multiple GPU IDs in `Training.gpus` for dramatically faster epochs on capable machines.
 * 🌀 **Generator EMA tracking**: optional exponential moving average weights for sharper validation and inference results.
 * 📊 **Clear monitoring**: PSNR, SSIM, LPIPS, qualitative panels, and Weights & Biases logging.
 
@@ -99,6 +100,8 @@ Train the GAN model.
 ```bash
 python train.py --config configs/config.yaml
 ```
+
+Multi-GPU training is enabled by setting `Training.gpus` in your config to a list of device indices (e.g. `[0, 1, 2, 3]`). The trainer automatically switches to Distributed Data Parallel (DDP), yielding significantly faster wall-clock times when scaling out across multiple GPUs.
 
 ### 2) Inference on Large Scenes
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -13,8 +13,7 @@ python train.py --config path/to/config.yaml
 
 * `--config / -c`: Path to a YAML file describing the experiment. Defaults to `configs/config_20m.yaml`.
 
-The script sets `CUDA_VISIBLE_DEVICES="0"` by default. Override this environment variable before launching if you want to select
-a different GPU or enable multi-GPU training.
+GPU assignment is handled directly in the configuration. Set `Training.gpus` to a list of device indices (for example `[0, 1, 2, 3]`) to enable multi-GPU training; a single value such as `[0]` keeps the run on one card. When more than one device is listed the trainer automatically activates PyTorch Lightning's Distributed Data Parallel (DDP) backend for significantly faster epochs.
 
 ## Initialisation steps
 
@@ -59,8 +58,8 @@ correlate files across tooling.
 
 The script builds a `Trainer` with the following notable arguments:
 
-* `accelerator='cuda'` and `devices=[0]` for single-GPU runs. Adjust to `devices=[0,1,...]` or use `devices='auto'` for multi-GPU
-  training.
+* `accelerator='cuda'` with `devices=config.Training.gpus`. When more than one device index is provided the script selects the
+  `ddp` strategy automatically, so scaling across multiple GPUs is as simple as enumerating them in the config.
 * `check_val_every_n_epoch=1` to evaluate after every epoch.
 * `limit_val_batches=250` as a safeguard against excessive validation time on large datasets.
 * `logger=[wandb_logger]` to register external logging backends (add `tb_logger` if you prefer TensorBoard-driven monitoring).


### PR DESCRIPTION
## Summary
- highlight the new multi-GPU DDP path in the README key features and quickstart instructions
- refresh the training guide to explain configuring `Training.gpus` and the automatic DDP strategy selection

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ee5c289d5c8327a532373ae3b13975