### PR TITLE
Improve test setup for reorganised package layout

### DIFF
--- a/opensr_srgan/tests/test_config_instantiation.py
+++ b/opensr_srgan/tests/test_config_instantiation.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import sys
 import importlib.util
+import sys
 import types
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -23,16 +24,25 @@ from opensr_srgan.data import data_utils
 # --- FIX: give the module a real name & register it in sys.modules ---
 _factory_path = ROOT / "_factory.py"
 _factory_spec = importlib.util.spec_from_file_location(
-    "opensr_srgan._factory", str(_factory_path)  # <<< changed
+    "opensr_srgan._factory", str(_factory_path)
 )
 assert _factory_spec and _factory_spec.loader
 _factory = importlib.util.module_from_spec(_factory_spec)
 
 # Register before executing so dataclasses & relative imports resolve
-sys.modules[_factory_spec.name] = _factory               # <<< changed
-_factory.__package__ = "opensr_srgan"                    # <<< changed
+sys.modules[_factory_spec.name] = _factory
+_factory.__package__ = "opensr_srgan"
 
 _factory_spec.loader.exec_module(_factory)  # type: ignore[assignment]
+
+
+@lru_cache(maxsize=None)
+def _instantiate_training_model(config_path: Path):
+    """Instantiate the training model once per unique config path."""
+
+    from opensr_srgan.model.SRGAN import SRGAN_model
+
+    return SRGAN_model(config_file_path=str(config_path))
 
 @pytest.mark.parametrize("config_name", ["config_10m.yaml", "config_20m.yaml"])
 def test_example_configs_can_instantiate(config_name: str, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -49,9 +59,7 @@ def test_example_configs_can_instantiate(config_name: str, monkeypatch: pytest.M
 
     monkeypatch.setattr(data_utils, "select_dataset", fake_select_dataset)
 
-    from opensr_srgan.model.SRGAN import SRGAN_model
-
-    model = SRGAN_model(config_file_path=str(config_path))
+    model = _instantiate_training_model(config_path)
     assert hasattr(model, "generator")
     assert hasattr(model, "discriminator")
 
@@ -89,8 +97,8 @@ def test_prebuilt_models_can_instantiate(preset: str, monkeypatch: pytest.Monkey
     hub_module.hf_hub_download = fake_hf_hub_download
     monkeypatch.setitem(sys.modules, "huggingface_hub", hub_module)
 
+    model = _factory.load_inference_model(preset, map_location="cpu")
     from opensr_srgan.model.SRGAN import SRGAN_model
 
-    model = _factory.load_inference_model(preset, map_location="cpu")
     assert isinstance(model, SRGAN_model)
     assert not model.training

--- a/opensr_srgan/tests/test_import.py
+++ b/opensr_srgan/tests/test_import.py
@@ -1,11 +1,16 @@
 import importlib
 import pkgutil
+import sys
 from pathlib import Path
 
 import pytest
 
 # Skip the whole file if torch isn't available (these modules depend on it)
 pytest.importorskip("torch")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 def test_package_discovery():
@@ -19,3 +24,37 @@ def test_package_discovery():
     assert importlib.import_module("opensr_srgan")
     expected = {"opensr_srgan.model", "opensr_srgan.utils", "opensr_srgan.data"}
     assert expected.issubset(discovered)
+
+
+def test_import_all_submodules():
+    """Import every package module to ensure the reorganised layout works."""
+
+    root = Path(__file__).resolve().parents[1]
+    module_names = {
+        name
+        for _, name, _ in pkgutil.walk_packages([str(root)], prefix="opensr_srgan.")
+        if ".tests" not in name
+    }
+
+    optional_dependencies = {
+        "opensr_srgan.train": {"wandb", "pytorch_lightning"},
+    }
+
+    optional_failures = []
+
+    for module_name in sorted(module_names):
+        try:
+            importlib.import_module(module_name)
+        except ModuleNotFoundError as exc:
+            missing = exc.name or ""
+            expected_missing = missing in optional_dependencies.get(module_name, set())
+            if expected_missing:
+                optional_failures.append((module_name, missing))
+                continue
+            raise
+
+    if optional_failures:
+        missing_info = ", ".join(
+            f"{module} (missing {dependency})" for module, dependency in optional_failures
+        )
+        pytest.skip(f"Optional dependencies missing for modules: {missing_info}")


### PR DESCRIPTION
## Summary
- add caching to the config instantiation test so SRGAN models are built once per config
- ensure the import test exercises every module in the reorganised package layout and tolerates optional dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f74a00bfd083278fb032653f5e1677