### PR TITLE
Add smoke tests for utility helpers

### DIFF
--- a/opensr_srgan/tests/test_data_utils_basic.py
+++ b/opensr_srgan/tests/test_data_utils_basic.py
@@ -1,0 +1,68 @@
+"""Sanity checks for :mod:`opensr_srgan.data.data_utils`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from torch.utils.data import TensorDataset
+
+from opensr_srgan.data import data_utils
+
+
+def _make_config(**overrides):
+    data_defaults = dict(
+        dataset_type="dummy",
+        train_batch_size=2,
+        val_batch_size=3,
+        num_workers=0,
+        prefetch_factor=2,
+    )
+    data_defaults.update(overrides)
+    return SimpleNamespace(Data=SimpleNamespace(**data_defaults))
+
+
+def test_datamodule_from_datasets_minimal_workers():
+    """The helper should honour explicit batch sizes and worker counts."""
+
+    cfg = _make_config()
+    dataset = TensorDataset(torch.arange(8))
+
+    dm = data_utils.datamodule_from_datasets(cfg, dataset, dataset)
+
+    train_loader = dm.train_dataloader()
+    val_loader = dm.val_dataloader()
+
+    assert train_loader.batch_size == 2
+    assert val_loader.batch_size == 3
+    assert train_loader.num_workers == 0
+    assert val_loader.num_workers == 0
+
+
+def test_datamodule_from_datasets_prefetch_when_workers_present():
+    """``prefetch_factor`` is only forwarded once workers are enabled."""
+
+    cfg = _make_config(num_workers=2, prefetch_factor=4)
+    dataset = TensorDataset(torch.arange(12))
+
+    dm = data_utils.datamodule_from_datasets(cfg, dataset, dataset)
+
+    train_loader = dm.train_dataloader()
+    val_loader = dm.val_dataloader()
+
+    assert train_loader.num_workers == 2
+    assert val_loader.num_workers == 2
+    assert train_loader.prefetch_factor == 4
+    assert val_loader.prefetch_factor == 4
+
+
+def test_select_dataset_unknown_raises():
+    """Unsupported dataset identifiers should fail loudly."""
+
+    cfg = SimpleNamespace(Data=SimpleNamespace(dataset_type="does-not-exist"))
+
+    with pytest.raises(NotImplementedError):
+        data_utils.select_dataset(cfg)

--- a/opensr_srgan/tests/test_factory.py
+++ b/opensr_srgan/tests/test_factory.py
@@ -1,0 +1,103 @@
+"""Unit tests for the lightweight factory helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+if "pytorch_lightning" not in sys.modules:
+    dummy_pl = ModuleType("pytorch_lightning")
+
+    class _DummyLightningModule:
+        pass
+
+    dummy_pl.LightningModule = _DummyLightningModule
+    sys.modules["pytorch_lightning"] = dummy_pl
+
+from opensr_srgan import _factory
+
+
+def test_maybe_download_accepts_existing_file(tmp_path):
+    ckpt = tmp_path / "weights.ckpt"
+    ckpt.write_bytes(b"binary")
+
+    with _factory._maybe_download(ckpt) as resolved:
+        assert resolved == ckpt
+
+
+def test_maybe_download_missing_file_raises(tmp_path):
+    missing = tmp_path / "missing.ckpt"
+
+    with pytest.raises(FileNotFoundError):
+        with _factory._maybe_download(missing):
+            pass
+
+
+class DummyEMA:
+    def __init__(self):
+        self.state = None
+
+    def load_state_dict(self, state):
+        self.state = state
+
+
+class DummySRGAN:
+    def __init__(self, config_file_path=None):
+        self.config_file_path = config_file_path
+        self.loaded_state = None
+        self.eval_called = False
+        self.ema = DummyEMA()
+
+    def load_state_dict(self, state_dict, strict=False):
+        self.loaded_state = (state_dict, strict)
+
+    def eval(self):
+        self.eval_called = True
+        return self
+
+
+def test_load_from_config_restores_checkpoint(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("key: value")
+
+    checkpoint_path = tmp_path / "model.ckpt"
+    checkpoint_path.write_bytes(b"ckpt")
+
+    monkeypatch.setattr(_factory, "SRGAN_model", DummySRGAN)
+
+    recorded = {}
+
+    def fake_load(path, map_location=None):
+        recorded["path"] = Path(path)
+        recorded["map_location"] = map_location
+        return {"state_dict": {"weight": 3}, "ema_state": {"ema": 1}}
+
+    monkeypatch.setattr(_factory.torch, "load", fake_load)
+
+    model = _factory.load_from_config(config_path, checkpoint_path, map_location="cpu")
+
+    assert isinstance(model, DummySRGAN)
+    assert model.config_file_path == str(config_path)
+    assert model.eval_called is True
+    assert model.loaded_state == ({"weight": 3}, False)
+    assert model.ema.state == {"ema": 1}
+    assert recorded["path"] == checkpoint_path
+    assert recorded["map_location"] == "cpu"
+
+
+def test_load_from_config_missing_config(tmp_path):
+    missing = tmp_path / "does_not_exist.yaml"
+
+    with pytest.raises(FileNotFoundError):
+        _factory.load_from_config(missing)
+
+
+def test_load_inference_model_unknown_preset():
+    with pytest.raises(ValueError):
+        _factory.load_inference_model("unknown")

--- a/opensr_srgan/tests/test_gpu_rank.py
+++ b/opensr_srgan/tests/test_gpu_rank.py
@@ -1,0 +1,40 @@
+"""Tests for GPU rank helper utilities."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+import pytest
+
+pytest.importorskip("numpy")
+
+from opensr_srgan.utils import gpu_rank
+
+
+def test_is_global_zero_defaults_to_true(monkeypatch):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.delenv("WORLD_SIZE", raising=False)
+
+    assert gpu_rank._is_global_zero() is True
+
+
+def test_is_global_zero_respects_environment(monkeypatch):
+    monkeypatch.delenv("RANK", raising=False)
+    monkeypatch.setenv("WORLD_SIZE", "4")
+
+    assert gpu_rank._is_global_zero() is True
+
+    monkeypatch.setenv("RANK", "2")
+    assert gpu_rank._is_global_zero() is False
+
+
+def test_is_global_zero_honours_distributed_module(monkeypatch):
+    dummy_dist = ModuleType("torch.distributed")
+    dummy_dist.is_available = lambda: True
+    dummy_dist.is_initialized = lambda: True
+    dummy_dist.get_rank = lambda: 1
+
+    monkeypatch.setitem(sys.modules, "torch.distributed", dummy_dist)
+
+    assert gpu_rank._is_global_zero() is False

--- a/opensr_srgan/tests/test_inference_basic.py
+++ b/opensr_srgan/tests/test_inference_basic.py
@@ -1,0 +1,75 @@
+"""Lightweight smoke tests for :mod:`opensr_srgan.inference`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from opensr_srgan import inference
+
+
+class DummyModel:
+    def __init__(self, config_file_path=None):
+        self.config_file_path = config_file_path
+        self.state_dict = None
+        self.device = None
+
+    def eval(self):
+        return self
+
+    def to(self, device):
+        self.device = device
+        return self
+
+    def load_state_dict(self, state, strict=False):
+        self.state_dict = (state, strict)
+
+    @classmethod
+    def load_from_checkpoint(cls, *args, **kwargs):
+        instance = cls(config_file_path="from_checkpoint")
+        instance.ckpt_args = (args, kwargs)
+        return instance
+
+
+def test_load_model_prefers_available_device(monkeypatch, tmp_path):
+    monkeypatch.setattr(inference, "SRGAN_model", DummyModel)
+    monkeypatch.setattr(inference.torch.cuda, "is_available", lambda: False)
+
+    model, device = inference.load_model(config_path="cfg.yaml")
+
+    assert isinstance(model, DummyModel)
+    assert model.config_file_path == "cfg.yaml"
+    assert device == "cpu"
+    assert model.device == "cpu"
+
+
+def test_load_model_falls_back_to_raw_state_dict(monkeypatch, tmp_path):
+    class RaisingDummy(DummyModel):
+        @classmethod
+        def load_from_checkpoint(cls, *args, **kwargs):
+            raise TypeError("unexpected argument")
+
+    ckpt_path = tmp_path / "weights.ckpt"
+    ckpt_path.write_bytes(b"checkpoint")
+
+    monkeypatch.setattr(inference, "SRGAN_model", RaisingDummy)
+
+    recorded = {}
+
+    def fake_load(path, map_location=None):
+        recorded["path"] = Path(path)
+        recorded["map_location"] = map_location
+        return {"state_dict": {"weight": 1}}
+
+    monkeypatch.setattr(inference.torch, "load", fake_load)
+    monkeypatch.setattr(inference.torch.cuda, "is_available", lambda: False)
+
+    model, device = inference.load_model(config_path="cfg.yaml", ckpt_path=str(ckpt_path))
+
+    assert recorded["path"] == ckpt_path
+    assert recorded["map_location"] == "cpu"
+    assert model.state_dict == ({"weight": 1}, False)
+    assert device == "cpu"

--- a/opensr_srgan/tests/test_normalizer.py
+++ b/opensr_srgan/tests/test_normalizer.py
@@ -1,0 +1,46 @@
+"""Tests for the configurable normalizer helper."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from opensr_srgan.data.utils.normalizer import Normalizer
+
+
+class DummyConfig(SimpleNamespace):
+    """Namespace helper that allows attribute-style access in tests."""
+
+
+def test_default_method_is_sen2_stretch():
+    cfg = DummyConfig(Data=DummyConfig())
+    normalizer = Normalizer(cfg)
+
+    tensor = torch.tensor([-0.5, 0.0, 0.75])
+    stretched = normalizer.normalize(tensor)
+    recovered = normalizer.denormalize(stretched)
+
+    assert normalizer.method == "sen2_stretch"
+    assert torch.allclose(recovered, torch.clamp(tensor, 0.0, 1.0), atol=1e-6)
+
+
+def test_alias_normalize_10k_is_supported():
+    cfg = DummyConfig(Data=DummyConfig(normalization="normalize_10k"))
+    normalizer = Normalizer(cfg)
+
+    tensor = torch.tensor([0.0, 1000.0, 2000.0])
+    normalized = normalizer.normalize(tensor)
+    recovered = normalizer.denormalize(normalized)
+
+    assert normalizer.method == "normalise_10k"
+    assert torch.allclose(recovered, torch.clamp(tensor, 0.0, 10000.0), atol=1e-4)
+
+
+def test_unknown_method_raises_value_error():
+    cfg = DummyConfig(Data=DummyConfig(normalization="unsupported"))
+
+    with pytest.raises(ValueError):
+        Normalizer(cfg)


### PR DESCRIPTION
## Summary
- add smoke tests for the dataset datamodule helper
- cover normalizer, inference loader, and factory logic with lightweight tests
- exercise GPU rank helper branch conditions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f74c64a64883278f22345e16c09443