### PR TITLE
Add basic instantiation tests for GAN models

### DIFF
--- a/opensr_srgan/tests/test_models/test_discriminators.py
+++ b/opensr_srgan/tests/test_models/test_discriminators.py
@@ -1,0 +1,22 @@
+"""Basic instantiation tests for discriminator architectures."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402
+
+from opensr_srgan.model.discriminators import Discriminator, PatchGANDiscriminator  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "discriminator_cls, kwargs",
+    [
+        (Discriminator, {}),
+        (PatchGANDiscriminator, {"input_nc": 3}),
+    ],
+)
+def test_discriminator_can_be_instantiated(discriminator_cls, kwargs):
+    """Ensure discriminator classes can be constructed with the provided arguments."""
+
+    instance = discriminator_cls(**kwargs)
+    assert isinstance(instance, nn.Module)

--- a/opensr_srgan/tests/test_models/test_generators.py
+++ b/opensr_srgan/tests/test_models/test_generators.py
@@ -1,0 +1,29 @@
+"""Basic instantiation tests for generator architectures."""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn  # noqa: E402  (import after torch availability check)
+
+from opensr_srgan.model.generators import (  # noqa: E402
+    ConditionalGANGenerator,
+    FlexibleGenerator,
+    Generator,
+    SRResNet,
+)
+
+
+@pytest.mark.parametrize(
+    "generator_cls, kwargs",
+    [
+        (SRResNet, {}),
+        (Generator, {}),
+        (FlexibleGenerator, {}),
+        (ConditionalGANGenerator, {}),
+    ],
+)
+def test_generator_can_be_instantiated(generator_cls, kwargs):
+    """Ensure generator classes can be constructed with default arguments."""
+
+    instance = generator_cls(**kwargs)
+    assert isinstance(instance, nn.Module)


### PR DESCRIPTION
## Summary
- add smoke tests that instantiate the available generator implementations
- add discriminator instantiation tests with minimal configuration

## Testing
- pytest opensr_srgan/tests/test_models/test_generators.py opensr_srgan/tests/test_models/test_discriminators.py

------
https://chatgpt.com/codex/tasks/task_e_68f8b5758844832786f82f9307dee35f