### PR TITLE
Refactor generator instantiation into factory

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,8 +8,9 @@ This document outlines how ESA OpenSR organises its super-resolution GAN, the ma
 
 * **Configuration ingestion.** Uses OmegaConf to load hyperparameters, dataset choices, and logging options. Convenience helpers
   such as `_pretrain_check()` and `_compute_adv_loss_weight()` translate config values into runtime behaviour.
-* **Model factory.** `get_models()` builds the generator and discriminator at runtime based on `Generator.model_type` and
-  `Discriminator.model_type`. Unsupported combinations fail fast with clear error messages.
+* **Model factory.** `get_models()` builds the generator and discriminator at runtime via the generator factory using
+  `Generator.model_type`/`block_type` and `Discriminator.model_type`. Unsupported combinations fail fast with clear error
+  messages.
 * **Loss construction.** `GeneratorContentLoss` (from `opensr_srgan.model.loss`) provides L1, spectral angle mapper (SAM), perceptual, and
   total-variation terms. Adversarial supervision uses `torch.nn.BCEWithLogitsLoss` with optional label smoothing.
 * **Optimiser scheduling.** `configure_optimizers()` returns paired Adam optimisers (generator + discriminator) with
@@ -40,7 +41,7 @@ The generator zoo lives under `opensr_srgan/model/generators/` and can be select
 * **Flexible residual families (`flexible_generator.py`).** Parameterised factory that instantiates residual, RCAB, RRDB, or
   large-kernel attention blocks while reusing the same interface. Channel counts, block depth, kernel sizes, and scaling factor
   are all read from the YAML file.
-* **Conditional GAN generator (`cgan_generator.py`).** Extends the flexible generator with conditioning inputs and latent noise,
+* **Stochastic GAN generator (`cgan_generator.py`).** Extends the flexible generator with conditioning inputs and latent noise,
   enabling experiments where auxiliary metadata influences the super-resolution output.
 * **Advanced variants (`SRGAN_advanced.py`).** Provides additional block implementations and compatibility aliases exposed in
   `__init__.py` for backwards compatibility.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,8 @@ stable validation imagery. The EMA is fully optional and controlled through the 
 
 | Key | Default | Description |
 | --- | --- | --- |
-| `model_type` | `cgan` | Generator architecture (`SRResNet`, `res`, `rcab`, `rrdb`, `lka`, `conditional_cgan`, `cgan`). |
+| `model_type` | `SRResNet` | Generator family (`SRResNet` or `stochastic_gan`). |
+| `block_type` | `standard` | SRResNet variant (`standard`, `res`, `rcab`, `rrdb`, `lka`). Ignored for `stochastic_gan`. |
 | `large_kernel_size` | `9` | Kernel size for input/output convolution layers. |
 | `small_kernel_size` | `3` | Kernel size for residual/attention blocks. |
 | `n_channels` | `96` | Base number of feature channels. |
@@ -109,12 +110,12 @@ performing sweeps:
 
 | Generator type | Recommended `n_channels` | Recommended `n_blocks` | Typical `scaling_factor` | Notes |
 | --- | --- | --- | --- | --- |
-| `SRResNet` | 64 | 16 | 4× | Canonical baseline with batch-norm residual blocks; scale can be 2×/4×/8× as needed. |
-| `res` | 96 | 32 | 4×–8× | Lightweight residual blocks without batch norm; works well for high-scale (8×) Sentinel data. |
-| `rcab` | 96 | 32 | 4×–8× | Attention-enhanced residual blocks; keep depth high to exploit channel attention. |
-| `rrdb` | 96 | 32 | 4×–8× | Dense residual blocks expand receptive field; expect higher VRAM use at 32 blocks. |
-| `lka` | 96 | 24–32 | 4×–8× | Large-kernel attention blocks stabilise at moderate depth; drop to 24 blocks if memory bound. |
-| `conditional_cgan`/`cgan` | 96 | 16 | 4× | Latent-modulated residual stack; pair with noise_dim≈128 and res_scale≈0.2 defaults. |
+| `SRResNet` (`block_type: standard`) | 64 | 16 | 4× | Canonical baseline with batch-norm residual blocks; scale can be 2×/4×/8× as needed. |
+| `SRResNet` (`block_type: res`) | 96 | 32 | 4×–8× | Lightweight residual blocks without batch norm; works well for high-scale (8×) Sentinel data. |
+| `SRResNet` (`block_type: rcab`) | 96 | 32 | 4×–8× | Attention-enhanced residual blocks; keep depth high to exploit channel attention. |
+| `SRResNet` (`block_type: rrdb`) | 96 | 32 | 4×–8× | Dense residual blocks expand receptive field; expect higher VRAM use at 32 blocks. |
+| `SRResNet` (`block_type: lka`) | 96 | 24–32 | 4×–8× | Large-kernel attention blocks stabilise at moderate depth; drop to 24 blocks if memory bound. |
+| `stochastic_gan` | 96 | 16 | 4× | Latent-modulated residual stack; pair with `noise_dim ≈ 128` and `res_scale ≈ 0.2` defaults. |
 
 ### Discriminator presets
 

--- a/opensr_srgan/__init__.py
+++ b/opensr_srgan/__init__.py
@@ -2,13 +2,30 @@
 
 from __future__ import annotations
 
-from .model.SRGAN import SRGAN_model
-from .train import train
-from ._factory import load_from_config, load_inference_model
+from typing import TYPE_CHECKING, Any
 
-__all__ = [
-    "SRGAN_model",
-    "train",
-    "load_from_config",
-    "load_inference_model",
-]
+__all__ = ["SRGAN_model", "train", "load_from_config", "load_inference_model"]
+
+if TYPE_CHECKING:  # pragma: no cover - type checkers only
+    from .model.SRGAN import SRGAN_model as SRGANModel
+    from .train import train as _train
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple import proxy
+    if name == "SRGAN_model":
+        from .model.SRGAN import SRGAN_model as _cls
+
+        globals()[name] = _cls
+        return _cls
+    if name == "train":
+        from .train import train as _train_fn
+
+        globals()[name] = _train_fn
+        return _train_fn
+    if name in {"load_from_config", "load_inference_model"}:
+        from . import _factory
+
+        attr = getattr(_factory, name)
+        globals()[name] = attr
+        return attr
+    raise AttributeError(f"module 'opensr_srgan' has no attribute '{name}'")

--- a/opensr_srgan/configs/config_10m.yaml
+++ b/opensr_srgan/configs/config_10m.yaml
@@ -76,7 +76,8 @@ Training:
 # ---------------------------------------------------------------------------- #
 # See Docs for archtecture details and suggestions
 Generator:
-  model_type: 'rrdb'           # Block type: ['SRResNet', 'res', 'rcab', 'rrdb', 'lka', 'conditional_cgan'/'cgan']
+  model_type: 'SRResNet'       # Generator family: ['SRResNet', 'stochastic_gan']
+  block_type: 'rrdb'           # SRResNet block variant: ['standard', 'res', 'rcab', 'rrdb', 'lka']
   large_kernel_size: 9         # Kernel for head and tail conv layers
   small_kernel_size: 3         # Kernel for intermediate blocks
   n_channels: 64               # Number of feature channels (original 64)

--- a/opensr_srgan/configs/config_20m.yaml
+++ b/opensr_srgan/configs/config_20m.yaml
@@ -75,7 +75,8 @@ Training:
 # 🧩 ARCHITECTURAL PARAMETERS
 # ---------------------------------------------------------------------------- #
 Generator:
-  model_type: 'rcab'           # Block type: ['SRResNet', 'res', 'rcab', 'rrdb', 'lka', 'conditional_cgan'/'cgan']
+  model_type: 'SRResNet'       # Generator family: ['SRResNet', 'stochastic_gan']
+  block_type: 'rcab'           # SRResNet block variant: ['standard', 'res', 'rcab', 'rrdb', 'lka']
   large_kernel_size: 9         # Kernel for head and tail conv layers
   small_kernel_size: 3         # Kernel for intermediate blocks
   n_channels: 96               # Number of feature channels (original 64)

--- a/opensr_srgan/configs/config_training_example.yaml
+++ b/opensr_srgan/configs/config_training_example.yaml
@@ -76,7 +76,8 @@ Training:
 # ---------------------------------------------------------------------------- #
 # See Docs for archtecture details and suggestions
 Generator:
-  model_type: 'SRResNet'           # Block type: ['SRResNet', 'res', 'rcab', 'rrdb', 'lka', 'conditional_cgan'/'cgan']
+  model_type: 'SRResNet'       # Generator family: ['SRResNet', 'stochastic_gan']
+  block_type: 'standard'       # SRResNet block variant: ['standard', 'res', 'rcab', 'rrdb', 'lka']
   large_kernel_size: 9         # Kernel for head and tail conv layers
   small_kernel_size: 3         # Kernel for intermediate blocks
   n_channels: 64               # Number of feature channels (original 64)

--- a/opensr_srgan/model/SRGAN.py
+++ b/opensr_srgan/model/SRGAN.py
@@ -18,6 +18,7 @@ from opensr_srgan.utils.logging_helpers import plot_tensors
 from opensr_srgan.utils.model_descriptions import print_model_summary
 from opensr_srgan.utils.radiometrics import histogram as histogram_match
 from opensr_srgan.utils.radiometrics import normalise_10k
+from opensr_srgan.model.generators import build_generator
 from opensr_srgan.model.model_blocks import ExponentialMovingAverage
 
 
@@ -56,8 +57,10 @@ class SRGAN_model(pl.LightningModule):
     Configuration overview (minimal)
     --------------------------------
     - **Model**: `in_bands` (int)
-    - **Generator**: `model_type` (`"SRResNet"`, `"res"`, `"rcab"`, `"rrdb"`, `"lka"`, `"conditional_cgan"`),
-    `n_channels`, `n_blocks`, `large_kernel_size`, `small_kernel_size`, `scaling_factor`
+        - **Generator**: `model_type` (`"SRResNet"`, `"stochastic_gan"`), optional
+        `block_type` for SRResNet variants (`"standard"`, `"res"`, `"rcab"`, `"rrdb"`,
+        `"lka"`), `n_channels`, `n_blocks`, `large_kernel_size`, `small_kernel_size`,
+        `scaling_factor`
     - **Discriminator**: `model_type` (`"standard"`, `"patchgan"`), `n_blocks` (optional)
     - **Training**:
     - `pretrain_g_only` (bool), `g_pretrain_steps` (int)
@@ -223,53 +226,7 @@ class SRGAN_model(pl.LightningModule):
         # SECTION: Initialize Generator
         # Purpose: Build generator network depending on selected architecture.
         # ======================================================================
-        generator_type = self.config.Generator.model_type
-
-        if generator_type == "SRResNet":
-            # Standard SRResNet generator
-            from opensr_srgan.model.generators.srresnet import Generator
-
-            self.generator = Generator(
-                in_channels=self.config.Model.in_bands,  # number of input channels
-                large_kernel_size=self.config.Generator.large_kernel_size,
-                small_kernel_size=self.config.Generator.small_kernel_size,
-                n_channels=self.config.Generator.n_channels,
-                n_blocks=self.config.Generator.n_blocks,
-                scaling_factor=self.config.Generator.scaling_factor,
-            )
-        elif generator_type in ["res", "rcab", "rrdb", "lka"]:
-            # Advanced generator variants (ResNet, RCAB, RRDB, etc.)
-            from opensr_srgan.model.generators.flexible_generator import (
-                FlexibleGenerator,
-            )
-
-            self.generator = FlexibleGenerator(
-                in_channels=self.config.Model.in_bands,
-                n_channels=self.config.Generator.n_channels,
-                n_blocks=self.config.Generator.n_blocks,
-                small_kernel=self.config.Generator.small_kernel_size,
-                large_kernel=self.config.Generator.large_kernel_size,
-                scale=self.config.Generator.scaling_factor,
-                block_type=self.config.Generator.model_type,
-            )
-        elif generator_type.lower() in ["conditional_cgan", "cgan"]:
-            from opensr_srgan.model.generators import ConditionalGANGenerator
-
-            self.generator = ConditionalGANGenerator(
-                in_channels=self.config.Model.in_bands,
-                n_channels=self.config.Generator.n_channels,
-                n_blocks=self.config.Generator.n_blocks,
-                small_kernel=self.config.Generator.small_kernel_size,
-                large_kernel=self.config.Generator.large_kernel_size,
-                scale=self.config.Generator.scaling_factor,
-                noise_dim=getattr(self.config.Generator, "noise_dim", 128),
-                res_scale=getattr(self.config.Generator, "res_scale", 0.2),
-            )
-
-        else:
-            raise ValueError(
-                f"Unknown generator model type: {self.config.Generator.model_type}"
-            )  # safety check
+        self.generator = build_generator(self.config)
 
         if mode == "train":  # only get discriminator in training mode
             # ======================================================================

--- a/opensr_srgan/model/__init__.py
+++ b/opensr_srgan/model/__init__.py
@@ -1,5 +1,19 @@
 """Model package exposing the SRGAN Lightning module."""
 
-from .SRGAN import SRGAN_model
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 __all__ = ["SRGAN_model"]
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .SRGAN import SRGAN_model as SRGANModel
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - import proxy
+    if name == "SRGAN_model":
+        from .SRGAN import SRGAN_model as _cls
+
+        globals()[name] = _cls
+        return _cls
+    raise AttributeError(f"module 'opensr_srgan.model' has no attribute '{name}'")

--- a/opensr_srgan/model/generators/__init__.py
+++ b/opensr_srgan/model/generators/__init__.py
@@ -2,7 +2,8 @@
 
 from .srresnet import SRResNet, Generator
 from .flexible_generator import FlexibleGenerator, flexible_generator
-from .cgan_generator import ConditionalGANGenerator
+from .cgan_generator import StochasticGenerator, ConditionalGANGenerator
+from .factory import build_generator
 from .SRGAN_advanced import *  # re-export compatibility symbols
 
 __all__ = [
@@ -10,5 +11,7 @@ __all__ = [
     "Generator",
     "FlexibleGenerator",
     "flexible_generator",
+    "StochasticGenerator",
     "ConditionalGANGenerator",
+    "build_generator",
 ]

--- a/opensr_srgan/model/generators/cgan_generator.py
+++ b/opensr_srgan/model/generators/cgan_generator.py
@@ -9,7 +9,7 @@ from torch import nn
 
 from ..model_blocks import make_upsampler
 
-__all__ = ["ConditionalGANGenerator"]
+__all__ = ["StochasticGenerator", "ConditionalGANGenerator"]
 
 
 class NoiseResBlock(nn.Module):
@@ -65,8 +65,8 @@ class NoiseResBlock(nn.Module):
         return x + self.res_scale * out
 
 
-class ConditionalGANGenerator(nn.Module):
-    """Conditional generator with latent noise modulation for super-resolution.
+class StochasticGenerator(nn.Module):
+    """Stochastic generator with latent noise modulation for super-resolution.
 
     Extends a standard SR generator by injecting stochastic latent noise through
     `NoiseResBlock`s, enabling diverse texture generation conditioned on the same
@@ -98,7 +98,7 @@ class ConditionalGANGenerator(nn.Module):
         tail (nn.Conv2d): Final convolution projecting to output space.
 
     Example:
-        >>> g = ConditionalGANGenerator(in_channels=3, scale=4)
+        >>> g = StochasticGenerator(in_channels=3, scale=4)
         >>> lr = torch.randn(1, 3, 64, 64)
         >>> sr, noise = g(lr, return_noise=True)
     """
@@ -187,3 +187,7 @@ class ConditionalGANGenerator(nn.Module):
         if return_noise:
             return sr, noise
         return sr
+
+
+# Backwards compatibility ---------------------------------------------------
+ConditionalGANGenerator = StochasticGenerator

--- a/opensr_srgan/model/generators/factory.py
+++ b/opensr_srgan/model/generators/factory.py
@@ -1,0 +1,161 @@
+"""Factory helpers for constructing generator backbones from a config object."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import nn
+
+from .cgan_generator import StochasticGenerator
+from .flexible_generator import FlexibleGenerator
+from .srresnet import Generator as SRResNetGenerator
+
+__all__ = ["build_generator"]
+
+
+_SRRESNET_BLOCK_ALIASES = {
+    "standard": {"standard", "srresnet", "vanilla", "classic", "default", "basic"},
+    "res": {"res", "residual", "resblocks"},
+    "rcab": {"rcab", "attention", "channel_attention"},
+    "rrdb": {"rrdb", "dense", "residual_in_residual"},
+    "lka": {"lka", "large_kernel", "large-kernel"},
+}
+
+_MODEL_TYPE_ALIASES = {
+    "srresnet": {"srresnet", "sr_resnet", "sr-resnet"},
+    "stochastic_gan": {
+        "stochastic_gan",
+        "stochastic",
+        "stochastic-gan",
+        "stochasticgan",
+        "cgan",
+        "conditional_cgan",
+        "conditional-gan",
+    },
+}
+
+
+def _normalise(value: str) -> str:
+    return value.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _match_alias(value: str, mapping: dict[str, set[str]]) -> str | None:
+    norm = _normalise(value)
+    for canonical, aliases in mapping.items():
+        if norm == canonical or norm in aliases:
+            return canonical
+    return None
+
+
+def _resolve_srresnet_block(generator_cfg: Any, model_type_hint: str) -> str:
+    """Determine which SRResNet variant should be instantiated."""
+
+    block_type = getattr(generator_cfg, "block_type", None)
+    if block_type is None:
+        block_type = model_type_hint
+
+    if block_type is None:
+        return "standard"
+
+    block_key = _normalise(str(block_type))
+
+    for canonical, aliases in _SRRESNET_BLOCK_ALIASES.items():
+        if block_key == canonical or block_key in aliases:
+            return canonical
+
+    raise ValueError(
+        "Unknown SRResNet block type '{block}'. Expected one of: {options}.".format(
+            block=block_type,
+            options=", ".join(sorted(_SRRESNET_BLOCK_ALIASES)),
+        )
+    )
+
+
+def build_generator(config: Any) -> nn.Module:
+    """Instantiate a generator module from the user configuration.
+
+    Parameters
+    ----------
+    config:
+        Resolved configuration object. The function expects at least the
+        ``Model`` and ``Generator`` sections used throughout the training
+        scripts.
+
+    Returns
+    -------
+    torch.nn.Module
+        Fully constructed generator ready for training or inference.
+    """
+
+    generator_cfg = config.Generator
+    model_cfg = config.Model
+
+    raw_model_type = str(getattr(generator_cfg, "model_type", "srresnet"))
+    model_type = _match_alias(raw_model_type, _MODEL_TYPE_ALIASES)
+
+    # Legacy support: configs that directly specified the block variant inside
+    # ``model_type`` (e.g., "rcab") should still build the flexible generator.
+    if model_type is None:
+        srresnet_block = _match_alias(raw_model_type, _SRRESNET_BLOCK_ALIASES)
+        if srresnet_block is not None:
+            model_type = "srresnet"
+        else:
+            raise ValueError(
+                "Unknown generator model type '{model_type}'. Expected one of: {options}.".format(
+                    model_type=raw_model_type,
+                    options=", ".join(sorted(_MODEL_TYPE_ALIASES)),
+                )
+            )
+    else:
+        srresnet_block = None
+
+    in_channels = int(getattr(model_cfg, "in_bands"))
+    large_kernel = int(getattr(generator_cfg, "large_kernel_size"))
+    small_kernel = int(getattr(generator_cfg, "small_kernel_size"))
+    n_channels = int(getattr(generator_cfg, "n_channels"))
+    n_blocks = int(getattr(generator_cfg, "n_blocks"))
+    scale = int(getattr(generator_cfg, "scaling_factor"))
+
+    if model_type == "srresnet":
+        block_variant = _resolve_srresnet_block(generator_cfg, srresnet_block)
+
+        if block_variant == "standard":
+            return SRResNetGenerator(
+                in_channels=in_channels,
+                large_kernel_size=large_kernel,
+                small_kernel_size=small_kernel,
+                n_channels=n_channels,
+                n_blocks=n_blocks,
+                scaling_factor=scale,
+            )
+
+        return FlexibleGenerator(
+            in_channels=in_channels,
+            n_channels=n_channels,
+            n_blocks=n_blocks,
+            small_kernel=small_kernel,
+            large_kernel=large_kernel,
+            scale=scale,
+            block_type=block_variant,
+        )
+
+    if model_type == "stochastic_gan":
+        noise_dim = int(getattr(generator_cfg, "noise_dim", 128))
+        res_scale = float(getattr(generator_cfg, "res_scale", 0.2))
+        return StochasticGenerator(
+            in_channels=in_channels,
+            n_channels=n_channels,
+            n_blocks=n_blocks,
+            small_kernel=small_kernel,
+            large_kernel=large_kernel,
+            scale=scale,
+            noise_dim=noise_dim,
+            res_scale=res_scale,
+        )
+
+    raise ValueError(
+        "Unhandled generator model type '{model_type}'. Expected one of: {options}.".format(
+            model_type=raw_model_type,
+            options=", ".join(sorted(_MODEL_TYPE_ALIASES)),
+        )
+    )

--- a/opensr_srgan/tests/test_models/test_generators.py
+++ b/opensr_srgan/tests/test_models/test_generators.py
@@ -1,6 +1,12 @@
-"""Basic instantiation tests for generator architectures."""
+"""Basic instantiation and factory tests for generator architectures."""
+
+from pathlib import Path
+import sys
 
 import pytest
+from omegaconf import OmegaConf
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 torch = pytest.importorskip("torch")
 from torch import nn  # noqa: E402  (import after torch availability check)
@@ -10,6 +16,8 @@ from opensr_srgan.model.generators import (  # noqa: E402
     FlexibleGenerator,
     Generator,
     SRResNet,
+    StochasticGenerator,
+    build_generator,
 )
 
 
@@ -19,7 +27,7 @@ from opensr_srgan.model.generators import (  # noqa: E402
         (SRResNet, {}),
         (Generator, {}),
         (FlexibleGenerator, {}),
-        (ConditionalGANGenerator, {}),
+        (StochasticGenerator, {}),
     ],
 )
 def test_generator_can_be_instantiated(generator_cls, kwargs):
@@ -27,3 +35,74 @@ def test_generator_can_be_instantiated(generator_cls, kwargs):
 
     instance = generator_cls(**kwargs)
     assert isinstance(instance, nn.Module)
+
+
+def test_conditional_alias_points_to_stochastic_generator():
+    """Legacy alias should reference the stochastic generator class."""
+
+    assert ConditionalGANGenerator is StochasticGenerator
+
+
+@pytest.mark.parametrize(
+    "generator_cfg, expected_cls",
+    [
+        (
+            {
+                "model_type": "SRResNet",
+                "block_type": "standard",
+                "large_kernel_size": 9,
+                "small_kernel_size": 3,
+                "n_channels": 64,
+                "n_blocks": 16,
+                "scaling_factor": 4,
+            },
+            Generator,
+        ),
+        (
+            {
+                "model_type": "SRResNet",
+                "block_type": "rcab",
+                "large_kernel_size": 9,
+                "small_kernel_size": 3,
+                "n_channels": 96,
+                "n_blocks": 32,
+                "scaling_factor": 8,
+            },
+            FlexibleGenerator,
+        ),
+        (
+            {
+                "model_type": "stochastic_gan",
+                "large_kernel_size": 9,
+                "small_kernel_size": 3,
+                "n_channels": 96,
+                "n_blocks": 16,
+                "scaling_factor": 4,
+            },
+            StochasticGenerator,
+        ),
+        (
+            {
+                "model_type": "rrdb",  # legacy direct variant
+                "large_kernel_size": 9,
+                "small_kernel_size": 3,
+                "n_channels": 96,
+                "n_blocks": 32,
+                "scaling_factor": 8,
+            },
+            FlexibleGenerator,
+        ),
+    ],
+)
+def test_build_generator_from_config(generator_cfg, expected_cls):
+    """Factory should create the appropriate generator variant for each config."""
+
+    config = OmegaConf.create(
+        {
+            "Model": {"in_bands": 4},
+            "Generator": generator_cfg,
+        }
+    )
+
+    generator = build_generator(config)
+    assert isinstance(generator, expected_cls)

--- a/opensr_srgan/utils/model_descriptions.py
+++ b/opensr_srgan/utils/model_descriptions.py
@@ -27,17 +27,28 @@ def print_model_summary(self):
     # ------------------------------------------------------------------
     # Derive human-readable generator description
     # ------------------------------------------------------------------
-    g_type = self.config.Generator.model_type
-    if g_type == "SRResNet":
-        g_desc = "SRResNet (Residual Blocks with BatchNorm)"
-    elif g_type == "res":
-        g_desc = "flexible_generator (Residual Blocks without BatchNorm)"
-    elif g_type == "rcab":
-        g_desc = "flexible_generator (RCAB Blocks with Channel Attention)"
-    elif g_type == "rrdb":
-        g_desc = "flexible_generator (RRDB Dense Residual Blocks)"
-    elif g_type == "lka":
-        g_desc = "flexible_generator (LKA Large-Kernel Attention Blocks)"
+    g_type = getattr(self.config.Generator, "model_type", "SRResNet")
+    g_type_norm = str(g_type).lower().replace("-", "_")
+    block_type = getattr(self.config.Generator, "block_type", None)
+
+    if g_type_norm in {"res", "rcab", "rrdb", "lka"} and block_type is None:
+        block_type = g_type_norm
+        g_type_norm = "srresnet"
+
+    block_desc_map = {
+        "standard": "Residual Blocks with BatchNorm",
+        "res": "Residual Blocks without BatchNorm",
+        "rcab": "RCAB Blocks with Channel Attention",
+        "rrdb": "RRDB Dense Residual Blocks",
+        "lka": "LKA Large-Kernel Attention Blocks",
+    }
+
+    if g_type_norm in {"srresnet", "sr_resnet"}:
+        block_key = "standard" if block_type is None else str(block_type).lower()
+        desc = block_desc_map.get(block_key, f"Custom Block Variant: {block_key}")
+        g_desc = f"SRResNet ({desc})"
+    elif g_type_norm in {"stochastic_gan", "cgan", "conditional_cgan"}:
+        g_desc = "Stochastic SRGAN (Latent-modulated Residual Blocks)"
     else:
         g_desc = f"Custom Generator Type: {g_type}"
 


### PR DESCRIPTION
## Summary
- add a dedicated generator factory that maps SRResNet block types and the stochastic GAN option from configuration
- rename the conditional GAN generator to stochastic GAN, adjust configuration samples, and update documentation accordingly
- tighten package initialisers to lazily import heavy dependencies and expand generator tests to cover the new factory logic

## Testing
- pytest opensr_srgan/tests/test_models/test_generators.py

------
https://chatgpt.com/codex/tasks/task_e_6900d23c85888327bec84537accbe1a4