### PR TITLE
Warn when overriding unsupported model options

### DIFF
--- a/opensr_srgan/configs/config_training_example.yaml
+++ b/opensr_srgan/configs/config_training_example.yaml
@@ -76,7 +76,7 @@ Training:
 # ---------------------------------------------------------------------------- #
 # See Docs for archtecture details and suggestions
 Generator:
-  model_type: 'SRResNet'       # Generator family: ['SRResNet', 'stochastic_gan']
+  model_type: 'SRResNet'       # Generator family: ['SRResNet', 'stochastic_gan', 'esrgan']
   block_type: 'standard'       # SRResNet block variant: ['standard', 'res', 'rcab', 'rrdb', 'lka']
   large_kernel_size: 9         # Kernel for head and tail conv layers
   small_kernel_size: 3         # Kernel for intermediate blocks
@@ -85,7 +85,7 @@ Generator:
   scaling_factor: 4            # Upscaling factor (e.g., 2×, 4×, 8×)
 
 Discriminator:
-  model_type: 'standard'       # Discriminator architecture selector ['standard', 'patchgan']
+  model_type: 'standard'       # Discriminator architecture selector ['standard', 'patchgan', 'esrgan']
   n_blocks: 8                  # Number of convolutional blocks / layers: ['standard': 8, 'patchgan': 3]
 
 # ============================================================================ #

--- a/opensr_srgan/model/discriminators/__init__.py
+++ b/opensr_srgan/model/discriminators/__init__.py
@@ -2,8 +2,10 @@
 
 from .srgan_discriminator import Discriminator
 from .patchgan import PatchGANDiscriminator
+from .esrgan import ESRGANDiscriminator
 
 __all__ = [
     "Discriminator",
     "PatchGANDiscriminator",
+    "ESRGANDiscriminator",
 ]

--- a/opensr_srgan/model/discriminators/esrgan.py
+++ b/opensr_srgan/model/discriminators/esrgan.py
@@ -1,0 +1,75 @@
+"""Discriminator architecture used in ESRGAN."""
+
+from __future__ import annotations
+
+from torch import Tensor, nn
+
+__all__ = ["ESRGANDiscriminator"]
+
+
+def _conv_block(
+    in_channels: int,
+    out_channels: int,
+    *,
+    kernel_size: int,
+    stride: int,
+    use_batch_norm: bool = True,
+) -> nn.Sequential:
+    padding = kernel_size // 2
+    layers: list[nn.Module] = [
+        nn.Conv2d(in_channels, out_channels, kernel_size, stride, padding=padding),
+    ]
+    if use_batch_norm:
+        layers.append(nn.BatchNorm2d(out_channels))
+    layers.append(nn.LeakyReLU(0.2, inplace=True))
+    return nn.Sequential(*layers)
+
+
+class ESRGANDiscriminator(nn.Module):
+    """Deep VGG-style discriminator introduced with ESRGAN."""
+
+    def __init__(
+        self,
+        *,
+        in_channels: int = 3,
+        base_channels: int = 64,
+        linear_size: int = 1024,
+    ) -> None:
+        super().__init__()
+
+        if base_channels <= 0:
+            raise ValueError("base_channels must be a positive integer.")
+
+        if linear_size <= 0:
+            raise ValueError("linear_size must be a positive integer.")
+
+        features: list[nn.Module] = [
+            nn.Conv2d(in_channels, base_channels, 3, 1, padding=1),
+            nn.LeakyReLU(0.2, inplace=True),
+            _conv_block(base_channels, base_channels, kernel_size=4, stride=2),
+            _conv_block(base_channels, base_channels * 2, kernel_size=3, stride=1),
+            _conv_block(base_channels * 2, base_channels * 2, kernel_size=4, stride=2),
+            _conv_block(base_channels * 2, base_channels * 4, kernel_size=3, stride=1),
+            _conv_block(base_channels * 4, base_channels * 4, kernel_size=4, stride=2),
+            _conv_block(base_channels * 4, base_channels * 8, kernel_size=3, stride=1),
+            _conv_block(base_channels * 8, base_channels * 8, kernel_size=4, stride=2),
+            _conv_block(base_channels * 8, base_channels * 16, kernel_size=3, stride=1),
+            _conv_block(base_channels * 16, base_channels * 16, kernel_size=4, stride=2),
+        ]
+
+        self.features = nn.Sequential(*features)
+        self.pool = nn.AdaptiveAvgPool2d(1)
+        self.classifier = nn.Sequential(
+            nn.Linear(base_channels * 16, linear_size),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Linear(linear_size, 1),
+        )
+
+        self.base_channels = base_channels
+        self.linear_size = linear_size
+        self.n_layers = 1 + 10  # first conv + stacked blocks
+
+    def forward(self, x: Tensor) -> Tensor:
+        feats = self.features(x)
+        pooled = self.pool(feats).view(x.size(0), -1)
+        return self.classifier(pooled)

--- a/opensr_srgan/model/generators/__init__.py
+++ b/opensr_srgan/model/generators/__init__.py
@@ -3,6 +3,7 @@
 from .srresnet import SRResNet, Generator
 from .flexible_generator import FlexibleGenerator, flexible_generator
 from .cgan_generator import StochasticGenerator, ConditionalGANGenerator
+from .esrgan import ESRGANGenerator
 from .factory import build_generator
 from .SRGAN_advanced import *  # re-export compatibility symbols
 
@@ -13,5 +14,6 @@ __all__ = [
     "flexible_generator",
     "StochasticGenerator",
     "ConditionalGANGenerator",
+    "ESRGANGenerator",
     "build_generator",
 ]

--- a/opensr_srgan/model/generators/esrgan.py
+++ b/opensr_srgan/model/generators/esrgan.py
@@ -1,0 +1,65 @@
+"""ESRGAN generator implementation built around RRDB blocks."""
+
+from __future__ import annotations
+
+from torch import Tensor, nn
+
+from ..model_blocks import RRDB, make_upsampler
+
+__all__ = ["ESRGANGenerator"]
+
+
+class ESRGANGenerator(nn.Module):
+    """Generator network used in ESRGAN.
+
+    The architecture follows the design introduced in "ESRGAN: Enhanced
+    Super-Resolution Generative Adversarial Networks" (Wang et al., 2018). It
+    stacks multiple Residual-in-Residual Dense Blocks (RRDB) and performs
+    PixelShuffle-based upsampling.
+    """
+
+    def __init__(
+        self,
+        *,
+        in_channels: int = 3,
+        out_channels: int | None = None,
+        n_features: int = 64,
+        n_blocks: int = 23,
+        growth_channels: int = 32,
+        res_scale: float = 0.2,
+        scale: int = 4,
+    ) -> None:
+        super().__init__()
+
+        if scale < 1 or scale & (scale - 1) != 0:
+            raise ValueError("ESRGANGenerator only supports power-of-two scales (1, 2, 4, 8, ...).")
+
+        if n_blocks < 1:
+            raise ValueError("ESRGANGenerator requires at least one RRDB block.")
+
+        if out_channels is None:
+            out_channels = in_channels
+
+        self.scale = scale
+        self.n_blocks = n_blocks
+        self.n_features = n_features
+        self.growth_channels = growth_channels
+
+        body_blocks = [RRDB(n_features, growth_channels, res_scale=res_scale) for _ in range(n_blocks)]
+
+        self.conv_first = nn.Conv2d(in_channels, n_features, 3, padding=1)
+        self.body = nn.Sequential(*body_blocks)
+        self.conv_body = nn.Conv2d(n_features, n_features, 3, padding=1)
+        self.upsampler = nn.Identity() if scale == 1 else make_upsampler(n_features, scale)
+        self.conv_hr = nn.Conv2d(n_features, n_features, 3, padding=1)
+        self.activation = nn.LeakyReLU(0.2, inplace=True)
+        self.conv_last = nn.Conv2d(n_features, out_channels, 3, padding=1)
+
+    def forward(self, x: Tensor) -> Tensor:
+        first = self.conv_first(x)
+        trunk = self.body(first)
+        body_out = self.conv_body(trunk)
+        feat = first + body_out
+        feat = self.upsampler(feat)
+        feat = self.activation(self.conv_hr(feat))
+        return self.conv_last(feat)

--- a/opensr_srgan/tests/test_models/test_discriminators.py
+++ b/opensr_srgan/tests/test_models/test_discriminators.py
@@ -1,14 +1,18 @@
 """Basic instantiation tests for discriminator architectures."""
 
 import pytest
+from omegaconf import OmegaConf
 
 torch = pytest.importorskip("torch")
+_ = pytest.importorskip("pytorch_lightning")
 from torch import nn  # noqa: E402
 
-from opensr_srgan.model.discriminators import (
+from opensr_srgan.model.SRGAN import SRGAN_model  # noqa: E402
+from opensr_srgan.model.discriminators import (  # noqa: E402
     Discriminator,
+    ESRGANDiscriminator,
     PatchGANDiscriminator,
-)  # noqa: E402
+)
 
 
 @pytest.mark.parametrize(
@@ -16,6 +20,7 @@ from opensr_srgan.model.discriminators import (
     [
         (Discriminator, {}),
         (PatchGANDiscriminator, {"input_nc": 3}),
+        (ESRGANDiscriminator, {}),
     ],
 )
 def test_discriminator_can_be_instantiated(discriminator_cls, kwargs):
@@ -23,3 +28,28 @@ def test_discriminator_can_be_instantiated(discriminator_cls, kwargs):
 
     instance = discriminator_cls(**kwargs)
     assert isinstance(instance, nn.Module)
+
+
+def test_esrgan_discriminator_warns_about_n_blocks_override(capsys):
+    """SRGAN model should inform users when ESRGAN ignores discriminator n_blocks."""
+
+    config = OmegaConf.create(
+        {
+            "Model": {"in_bands": 3},
+            "Generator": {"model_type": "srresnet", "scaling_factor": 4},
+            "Discriminator": {"model_type": "esrgan", "n_blocks": 5},
+        }
+    )
+
+    model = SRGAN_model.__new__(SRGAN_model)
+    model.config = config
+    model.mode = "train"
+    model.generator = None
+    model.discriminator = None
+
+    model.get_models("train")
+
+    captured = capsys.readouterr()
+    assert (
+        "[Discriminator:esrgan] Ignoring unsupported configuration options: n_blocks." in captured.out
+    )

--- a/opensr_srgan/utils/model_descriptions.py
+++ b/opensr_srgan/utils/model_descriptions.py
@@ -49,6 +49,8 @@ def print_model_summary(self):
         g_desc = f"SRResNet ({desc})"
     elif g_type_norm in {"stochastic_gan", "cgan", "conditional_cgan"}:
         g_desc = "Stochastic SRGAN (Latent-modulated Residual Blocks)"
+    elif g_type_norm == "esrgan":
+        g_desc = "ESRGAN (RRDB Residual-in-Residual Dense Network)"
     else:
         g_desc = f"Custom Generator Type: {g_type}"
 
@@ -85,11 +87,27 @@ def print_model_summary(self):
     print(f"   • Architecture:      {g_desc}")
     print(f"   • Resolution:        {res_str}")
     print(f"   • Input Channels:    {self.config.Model.in_bands}")
-    print(f"   • Feature Channels:  {self.config.Generator.n_channels}")
-    print(f"   • Residual Blocks:   {self.config.Generator.n_blocks}")
-    print(
-        f"   • Kernel Sizes:      small={self.config.Generator.small_kernel_size}, large={self.config.Generator.large_kernel_size}"
+    feature_channels = getattr(self.config.Generator, "n_channels", None)
+    if feature_channels is not None:
+        print(f"   • Feature Channels:  {feature_channels}")
+
+    block_count = getattr(
+        self.config.Generator,
+        "n_blocks",
+        getattr(self.generator, "n_blocks", None),
     )
+    if block_count is not None:
+        print(f"   • Residual Blocks:   {block_count}")
+
+    small_kernel = getattr(self.config.Generator, "small_kernel_size", None)
+    large_kernel = getattr(self.config.Generator, "large_kernel_size", None)
+    if small_kernel is not None or large_kernel is not None:
+        print(
+            "   • Kernel Sizes:      small={small}, large={large}".format(
+                small=small_kernel if small_kernel is not None else "N/A",
+                large=large_kernel if large_kernel is not None else "N/A",
+            )
+        )
     print(f"   • Params:            {g_params:.2f} M\n")
 
     # ------------------------------------------------------------------
@@ -108,6 +126,8 @@ def print_model_summary(self):
 
     if d_type == "patchgan":
         d_desc = "PatchGAN"
+    elif d_type == "esrgan":
+        d_desc = "ESRGAN"
     else:
         d_desc = "SRGAN"
 


### PR DESCRIPTION
## Summary
- emit console notices when the ESRGAN generator/discriminator (and the stochastic generator) ignore SRResNet-specific options
- refactor the generator factory helpers to centralise override handling
- cover the new warnings with targeted unit tests

## Testing
- pytest opensr_srgan/tests/test_models/test_generators.py opensr_srgan/tests/test_models/test_discriminators.py

------
https://chatgpt.com/codex/tasks/task_e_6900db307f9883278d2cda5af57d55a2