### PR TITLE
Expose package version attribute

### DIFF
--- a/opensr_srgan/__init__.py
+++ b/opensr_srgan/__init__.py
@@ -4,7 +4,23 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__all__ = ["SRGAN_model", "train", "load_from_config", "load_inference_model"]
+try:  # pragma: no cover - import shim for Python <3.8
+    from importlib.metadata import PackageNotFoundError, version as _pkg_version
+except ModuleNotFoundError:  # pragma: no cover - fallback for very old Python
+    from importlib_metadata import PackageNotFoundError, version as _pkg_version  # type: ignore
+
+__all__ = [
+    "SRGAN_model",
+    "train",
+    "load_from_config",
+    "load_inference_model",
+    "__version__",
+]
+
+try:  # pragma: no cover - depends on installation metadata
+    __version__ = _pkg_version("opensr-srgan")
+except PackageNotFoundError:  # pragma: no cover - local source tree fallback
+    __version__ = "0.0.0"
 
 if TYPE_CHECKING:  # pragma: no cover - type checkers only
     from .model.SRGAN import SRGAN_model as SRGANModel

--- a/opensr_srgan/tests/test_version.py
+++ b/opensr_srgan/tests/test_version.py
@@ -1,0 +1,6 @@
+from opensr_srgan import __version__
+
+
+def test_version_is_a_string():
+    assert isinstance(__version__, str)
+    assert __version__


### PR DESCRIPTION
## Summary
- add an importlib-based lookup so `opensr_srgan.__version__` is available for consumers
- ensure the version attribute is exported through the package `__all__`
- add a regression test that confirms the attribute is present and non-empty

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'opensr_srgan' / 'pytorch_lightning')*

------
https://chatgpt.com/codex/tasks/task_e_6901f06c15bc8327856d443155623f69