### PR TITLE
Fix trainer kwargs test config missing optimizer section

### DIFF
--- a/opensr_srgan/tests/test_utils/test_trainer_kwargs.py
+++ b/opensr_srgan/tests/test_utils/test_trainer_kwargs.py
@@ -83,7 +83,18 @@ def _make_config(**training_overrides):
         "max_epochs": 5,
     }
     base_training.update(training_overrides)
-    return OmegaConf.create({"Training": base_training})
+
+    return OmegaConf.create(
+        {
+            "Training": base_training,
+            # ``build_lightning_kwargs`` expects optimiser settings for gradient
+            # clipping, so provide the minimal structure required by the real
+            # configuration files.
+            "Optimizers": {
+                "gradient_clip_val": 0.0,
+            },
+        }
+    )
 
 
 def _call_builder(config, resume_ckpt=None):


### PR DESCRIPTION
## Summary
- extend the test helper config in `test_trainer_kwargs` to include the Optimizers block required by `build_lightning_kwargs`

## Testing
- pytest opensr_srgan/tests/test_utils/test_trainer_kwargs.py

------
https://chatgpt.com/codex/tasks/task_e_6901f6a031a48327a5e99d2c4f5a6523