### PR TITLE
Add flexible normalization strategies and docs

### DIFF
--- a/opensr_srgan/data/utils/normalizer.py
+++ b/opensr_srgan/data/utils/normalizer.py
@@ -3,11 +3,30 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from functools import partial
+from importlib import import_module
+from typing import Any, Callable, Dict, Mapping, MutableMapping, Optional, Tuple
 
 import torch
 
-from ...utils.radiometrics import normalise_10k, sen2_stretch
+from ...utils.radiometrics import (
+    normalise_10k,
+    normalise_10k_signed,
+    normalise_s2,
+    sen2_stretch,
+    zero_one_signed,
+)
+
+
+NormalizationFn = Callable[[torch.Tensor], torch.Tensor]
+
+
+@dataclass(frozen=True)
+class NormalizationStrategy:
+    """Container storing forward/backward callable pairs."""
+
+    normalize: NormalizationFn
+    denormalize: NormalizationFn
 
 
 @dataclass
@@ -31,33 +50,78 @@ class Normalizer:
     helpers that downstream components can reuse without importing
     :mod:`utils.spectral_helpers` directly.
 
-    Supported methods include Sentinel-2 specific helpers such as
-    ``"sen2_stretch"`` (contrast stretch) and ``"normalise_10k"`` (scale
-    reflectance-like values stored in the ``[0, 10000]`` range).
+    Supported methods include remote-sensing-focused helpers such as
+    ``"normalise_10k"`` (0–10000 reflectance → ``[0, 1]``),
+    ``"normalise_10k_signed"`` (0–10000 reflectance → ``[-1, 1]``),
+    ``"normalise_s2"`` (Sentinel-2 symmetric stretch), ``"zero_one"`` (clamp to
+    ``[0, 1]``) and ``"zero_one_signed"`` (``[0, 1]`` ↔ ``[-1, 1]``). Custom
+    strategies can be registered by providing a mapping with
+    ``{"name": "custom", "normalize": "module:callable", ...}`` in the
+    configuration.
     """
 
-    _SUPPORTED_METHODS = {"normalise_10k", "sen2_stretch"}
+    _STANDARD_METHODS: Dict[str, NormalizationStrategy] = {
+        "sen2_stretch": NormalizationStrategy(
+            normalize=sen2_stretch,
+            denormalize=lambda tensor: torch.clamp(tensor * (3.0 / 10.0), 0.0, 1.0),
+        ),
+        "normalise_10k": NormalizationStrategy(
+            normalize=partial(normalise_10k, stage="norm"),
+            denormalize=partial(normalise_10k, stage="denorm"),
+        ),
+        "normalise_10k_signed": NormalizationStrategy(
+            normalize=partial(normalise_10k_signed, stage="norm"),
+            denormalize=partial(normalise_10k_signed, stage="denorm"),
+        ),
+        "normalise_s2": NormalizationStrategy(
+            normalize=partial(normalise_s2, stage="norm"),
+            denormalize=partial(normalise_s2, stage="denorm"),
+        ),
+        "zero_one": NormalizationStrategy(
+            normalize=lambda tensor: torch.clamp(tensor, 0.0, 1.0),
+            denormalize=lambda tensor: torch.clamp(tensor, 0.0, 1.0),
+        ),
+        "zero_one_signed": NormalizationStrategy(
+            normalize=partial(zero_one_signed, stage="norm"),
+            denormalize=partial(zero_one_signed, stage="denorm"),
+        ),
+        "identity": NormalizationStrategy(
+            normalize=lambda tensor: tensor,
+            denormalize=lambda tensor: tensor,
+        ),
+    }
+
+    _ALIASES: Dict[str, str] = {
+        "normalize_10k": "normalise_10k",
+        "reflectance": "normalise_10k",
+        "reflectance_0_1": "normalise_10k",
+        "reflectance_signed": "normalise_10k_signed",
+        "normalize_10k_signed": "normalise_10k_signed",
+        "sentinel2": "normalise_10k",
+        "sentinel2_signed": "normalise_10k_signed",
+        "s2": "normalise_10k",
+        "s2_signed": "normalise_10k_signed",
+        "normalize_s2": "normalise_s2",
+        "zero_to_one": "zero_one",
+        "zero_one_range": "zero_one",
+        "signed_zero_one": "zero_one_signed",
+        "minusone_one": "zero_one_signed",
+        "none": "identity",
+    }
 
     def __init__(self, config: Any):
         data_cfg = getattr(config, "Data", None)
-        method = None
+        raw_cfg: Any = None
         if data_cfg is not None:
-            method = getattr(data_cfg, "normalization", None)
-            if method is None and isinstance(data_cfg, dict):
-                method = data_cfg.get("normalization")
-        if method is None:
-            method = "sen2_stretch"
+            raw_cfg = getattr(data_cfg, "normalization", None)
+            if raw_cfg is None and isinstance(data_cfg, dict):
+                raw_cfg = data_cfg.get("normalization")
+        if raw_cfg is None:
+            raw_cfg = "sen2_stretch"
 
-        method = str(method).strip().lower()
-        if method == "normalize_10k":
-            method = "normalise_10k"
-        if method not in self._SUPPORTED_METHODS:
-            supported = ", ".join(sorted(self._SUPPORTED_METHODS))
-            raise ValueError(
-                f"Unsupported normalization '{method}'. Supported methods: {supported}."
-            )
-
+        method, strategy = self._resolve_strategy(raw_cfg)
         self._cfg = _NormalizerConfig(method=method)
+        self._strategy = strategy
 
     @property
     def method(self) -> str:
@@ -68,17 +132,139 @@ class Normalizer:
     def normalize(self, tensor: torch.Tensor) -> torch.Tensor:
         """Normalize ``tensor`` according to the configured method."""
 
-        if self.method == "sen2_stretch":
-            return sen2_stretch(tensor)
-        if self.method == "normalise_10k":
-            return normalise_10k(tensor, stage="norm")
-        raise RuntimeError(f"Unhandled normalization method: {self.method}")
+        return self._strategy.normalize(tensor)
 
     def denormalize(self, tensor: torch.Tensor) -> torch.Tensor:
         """Invert the normalization previously applied by :meth:`normalize`."""
 
-        if self.method == "sen2_stretch":
-            return torch.clamp(tensor * (3.0 / 10.0), 0.0, 1.0)
-        if self.method == "normalise_10k":
-            return normalise_10k(tensor, stage="denorm")
-        raise RuntimeError(f"Unhandled normalization method: {self.method}")
+        return self._strategy.denormalize(tensor)
+
+    @classmethod
+    def available_methods(cls) -> Tuple[str, ...]:
+        """Return the canonical names of built-in normalization strategies."""
+
+        return tuple(sorted(cls._STANDARD_METHODS.keys()))
+
+    def _resolve_strategy(
+        self, raw_cfg: Any
+    ) -> Tuple[str, NormalizationStrategy]:
+        """Resolve ``raw_cfg`` into a normalisation strategy.
+
+        Parameters
+        ----------
+        raw_cfg : Any
+            Configuration value extracted from ``Data.normalization``. Can be a
+            string alias, a mapping with ``name``/``method`` keys, or a mapping
+            describing custom callables.
+        """
+
+        if isinstance(raw_cfg, Mapping):
+            name = raw_cfg.get("name") or raw_cfg.get("method") or "custom"
+            name = str(name).strip().lower()
+            name = name.replace("normalize", "normalise")
+            if name == "custom":
+                strategy = self._build_custom_strategy(raw_cfg)
+                return "custom", strategy
+            raw_cfg = name
+
+        if not isinstance(raw_cfg, str):
+            raise TypeError(
+                "Normalization config must be a string or mapping, "
+                f"received: {type(raw_cfg)!r}"
+            )
+
+        method = raw_cfg.strip().lower()
+        method = method.replace("normalize", "normalise")
+        method = self._ALIASES.get(method, method)
+
+        if method == "custom":
+            raise ValueError(
+                "Use a mapping with 'name: custom' and callable paths to configure custom normalization."
+            )
+
+        try:
+            strategy = self._STANDARD_METHODS[method]
+        except KeyError as exc:
+            supported = ", ".join(sorted(self._STANDARD_METHODS))
+            raise ValueError(
+                f"Unsupported normalization '{raw_cfg}'. Supported methods: {supported}."
+            ) from exc
+
+        return method, strategy
+
+    def _build_custom_strategy(
+        self, cfg: Mapping[str, Any]
+    ) -> NormalizationStrategy:
+        """Instantiate a strategy from user-supplied callables."""
+
+        if "normalize" not in cfg:
+            raise ValueError(
+                "Custom normalization requires a 'normalize' callable path."
+            )
+
+        normalize_path = cfg["normalize"]
+        denormalize_path = cfg.get("denormalize")
+
+        shared_kwargs = dict(cfg.get("kwargs", {}))
+        norm_kwargs = {**shared_kwargs, **cfg.get("normalize_kwargs", {})}
+        denorm_kwargs = {**shared_kwargs, **cfg.get("denormalize_kwargs", {})}
+
+        normalize_fn = _load_callable(normalize_path, norm_kwargs)
+        if denormalize_path is None:
+            if denorm_kwargs:
+                raise ValueError(
+                    "'denormalize_kwargs' provided without a 'denormalize' callable."
+                )
+            denormalize_fn = lambda tensor: tensor
+        else:
+            denormalize_fn = _load_callable(denormalize_path, denorm_kwargs)
+
+        return NormalizationStrategy(
+            normalize=normalize_fn,
+            denormalize=denormalize_fn,
+        )
+
+
+def _load_callable(
+    path: Any, kwargs: Optional[MutableMapping[str, Any]]
+) -> NormalizationFn:
+    """Import ``path`` and partially apply ``kwargs`` if provided."""
+
+    if callable(path):
+        func = path  # already a callable (useful for tests)
+    else:
+        if not isinstance(path, str):
+            raise TypeError(
+                "Normalization callable paths must be strings or callables."
+            )
+        module_name, attr = _split_import_path(path)
+        module = import_module(module_name)
+        func = getattr(module, attr)
+        if not callable(func):
+            raise TypeError(
+                f"Imported object '{path}' is not callable (type={type(func)!r})."
+            )
+
+    call_kwargs: Dict[str, Any] = dict(kwargs or {})
+
+    if call_kwargs:
+        bound = partial(func, **call_kwargs)
+    else:
+        bound = func
+
+    return lambda tensor: bound(tensor)
+
+
+def _split_import_path(path: str) -> Tuple[str, str]:
+    """Split ``module.attr`` or ``module:attr`` import paths."""
+
+    if ":" in path:
+        module_name, attr = path.split(":", 1)
+    else:
+        module_name, _, attr = path.rpartition(".")
+    if not module_name or not attr:
+        raise ValueError(
+            "Normalization callable paths must include a module and attribute, "
+            f"received: '{path}'."
+        )
+    return module_name, attr

--- a/opensr_srgan/tests/helpers/__init__.py
+++ b/opensr_srgan/tests/helpers/__init__.py
@@ -1,0 +1,3 @@
+"""Test helpers for normalisation utilities."""
+
+__all__ = []

--- a/opensr_srgan/tests/helpers/custom_norms.py
+++ b/opensr_srgan/tests/helpers/custom_norms.py
@@ -1,0 +1,17 @@
+"""Custom normalisation helpers used in the test-suite."""
+
+from __future__ import annotations
+
+import torch
+
+
+def halve(tensor: torch.Tensor) -> torch.Tensor:
+    """Scale the input by 0.5."""
+
+    return tensor * 0.5
+
+
+def double(tensor: torch.Tensor) -> torch.Tensor:
+    """Reverse :func:`halve` by scaling the input by 2."""
+
+    return tensor * 2.0

--- a/opensr_srgan/tests/test_data/test_normalizer.py
+++ b/opensr_srgan/tests/test_data/test_normalizer.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+import torch
+
+from opensr_srgan.data.utils.normalizer import Normalizer
+from opensr_srgan.tests.helpers import custom_norms
+
+
+def _build_cfg(value):
+    return SimpleNamespace(Data=SimpleNamespace(normalization=value))
+
+
+def test_alias_resolves_reflectance_signed():
+    cfg = _build_cfg("reflectance_signed")
+    normalizer = Normalizer(cfg)
+
+    assert normalizer.method == "normalise_10k_signed"
+
+    tensor = torch.tensor([0.0, 5000.0])
+    normalized = normalizer.normalize(tensor)
+    restored = normalizer.denormalize(normalized)
+
+    assert torch.all(normalized <= 1) and torch.all(normalized >= -1)
+    assert torch.allclose(restored, tensor, atol=1e-5)
+
+
+def test_custom_strategy_roundtrip_via_import_path():
+    cfg = _build_cfg(
+        {
+            "name": "custom",
+            "normalize": "opensr_srgan.tests.helpers.custom_norms:halve",
+            "denormalize": "opensr_srgan.tests.helpers.custom_norms:double",
+        }
+    )
+
+    normalizer = Normalizer(cfg)
+    x = torch.ones(4) * 8
+    y = normalizer.normalize(x)
+    z = normalizer.denormalize(y)
+
+    assert normalizer.method == "custom"
+    assert torch.allclose(y, torch.ones_like(x) * 4)
+    assert torch.allclose(z, x)
+
+
+def test_custom_strategy_accepts_callables():
+    cfg = _build_cfg(
+        {
+            "name": "custom",
+            "normalize": custom_norms.halve,
+            "denormalize": custom_norms.double,
+        }
+    )
+
+    normalizer = Normalizer(cfg)
+    x = torch.tensor([10.0])
+    assert torch.allclose(normalizer.denormalize(normalizer.normalize(x)), x)
+
+
+def test_custom_strategy_supports_kwargs():
+    cfg = _build_cfg(
+        {
+            "name": "custom",
+            "normalize": "opensr_srgan.utils.radiometrics:normalise_10k",
+            "normalize_kwargs": {"stage": "norm"},
+            "denormalize": "opensr_srgan.utils.radiometrics:normalise_10k",
+            "denormalize_kwargs": {"stage": "denorm"},
+        }
+    )
+
+    normalizer = Normalizer(cfg)
+    x = torch.tensor([0.0, 10000.0])
+    assert torch.allclose(normalizer.denormalize(normalizer.normalize(x)), x)
+
+
+def test_available_methods_list_standard_entries():
+    methods = Normalizer.available_methods()
+    expected = {"normalise_10k", "normalise_10k_signed", "zero_one", "zero_one_signed"}
+    assert expected.issubset(set(methods))
+
+
+def test_identity_alias_none_behaves_like_passthrough():
+    cfg = _build_cfg("none")
+    normalizer = Normalizer(cfg)
+
+    x = torch.randn(3, 3)
+    assert normalizer.method == "identity"
+    assert torch.allclose(normalizer.normalize(x), x)
+    assert torch.allclose(normalizer.denormalize(x), x)

--- a/opensr_srgan/utils/__init__.py
+++ b/opensr_srgan/utils/__init__.py
@@ -2,11 +2,20 @@
 
 from .logging_helpers import plot_tensors
 from .model_descriptions import print_model_summary
-from .radiometrics import histogram, normalise_10k
+from .radiometrics import (
+    histogram,
+    normalise_10k,
+    normalise_10k_signed,
+    normalise_s2,
+    zero_one_signed,
+)
 
 __all__ = [
     "plot_tensors",
     "print_model_summary",
     "histogram",
     "normalise_10k",
+    "normalise_10k_signed",
+    "normalise_s2",
+    "zero_one_signed",
 ]


### PR DESCRIPTION
## Summary
- extend the data Normalizer with additional remote-sensing presets and support for custom callables
- document the available normalization aliases and configuration patterns for user-defined functions
- export new normalization utilities and cover them with targeted tests

## Testing
- PYTHONPATH=. pytest opensr_srgan/tests/test_utils/test_radiometrics.py opensr_srgan/tests/test_data/test_normalizer.py

------
https://chatgpt.com/codex/tasks/task_e_6901fc6384508327b4fb9fa27f9ceafe