### PR TITLE
New Dataset for traditional LR/HR folder structure

### DIFF
--- a/opensr_srgan/data/dataset_selector.py
+++ b/opensr_srgan/data/dataset_selector.py
@@ -125,7 +125,37 @@ def select_dataset(config):
         path = "example_dataset/"
         ds_train = ExampleDataset(folder=path, phase="train")
         ds_val = ExampleDataset(folder=path, phase="val")
-        
+
+    elif dataset_selection == "LRHRFolderDataset":
+        from opensr_srgan.data.lrhr_folder.lrhr_folder_dataset import LRHRFolderDataset
+
+        path = getattr(config.Data, "dataset_root", "data/")
+        normalization = getattr(config.Data, "normalization", "identity")
+        ds_train_raw = LRHRFolderDataset(
+            root_folder=path,
+            phase="train",
+            normalization=normalization,
+        )
+        ds_val_raw = LRHRFolderDataset(
+            root_folder=path,
+            phase="val",
+            normalization=normalization,
+        )
+
+        # Keep training loop compatibility: model expects (lr, hr) tuples.
+        class _TupleAdapter:
+            def __init__(self, dataset):
+                self.dataset = dataset
+
+            def __len__(self):
+                return len(self.dataset)
+
+            def __getitem__(self, idx):
+                sample = self.dataset[idx]
+                return sample["LR"], sample["HR"]
+
+        ds_train = _TupleAdapter(ds_train_raw)
+        ds_val = _TupleAdapter(ds_val_raw)
 
     else:
         # Centralized error so unsupported keys fail loudly & clearly.

--- a/opensr_srgan/data/lrhr_folder/lrhr_folder_dataset.py
+++ b/opensr_srgan/data/lrhr_folder/lrhr_folder_dataset.py
@@ -1,0 +1,128 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import rasterio
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from opensr_srgan.data.utils.normalizer import Normalizer
+
+
+class LRHRFolderDataset(Dataset):
+    """Dataset for paired LR/HR files in a fixed split-by-folder layout.
+
+    Expected structure:
+
+    root_folder/
+      train/
+        LR/
+          image_001.npy
+          image_002.npy
+        HR/
+          image_001.npy
+          image_002.npy
+      val/
+        LR/
+        HR/
+      test/
+        LR/
+        HR/
+
+    Notes:
+    - The selected ``phase`` must be one of: ``train``, ``val``, ``test``.
+    - Files are paired by exact filename between ``LR`` and ``HR``.
+    - Every LR file in the selected phase must have a matching HR file.
+    - Returned sample format is:
+      ``{"LR": torch.Tensor, "HR": torch.Tensor, "filename": str}``.
+    - Optional ``normalization`` accepts the same values used in the project
+      config (e.g. ``normalise_10k``, ``normalise_10k_signed``,
+      ``normalise_s2``, ``sen2_stretch``, ``zero_one_signed``).
+    """
+
+    VALID_PHASES = {"train", "val", "test"}
+
+    def __init__(self, root_folder, phase="train", normalization="identity"):
+        self.root_folder = Path(root_folder)
+        self.phase = phase
+        self.normalization = normalization
+
+        cfg = SimpleNamespace(Data=SimpleNamespace(normalization=self.normalization))
+        self.normalizer = Normalizer(cfg)
+
+        if phase not in self.VALID_PHASES:
+            raise ValueError(
+                f"Unknown phase '{phase}'. Expected one of {sorted(self.VALID_PHASES)}."
+            )
+        if not self.root_folder.is_dir():
+            raise FileNotFoundError(f"Dataset root folder '{self.root_folder}' does not exist.")
+
+        phase_dir = self.root_folder / phase
+        self.lr_dir = phase_dir / "LR"
+        self.hr_dir = phase_dir / "HR"
+
+        if not self.lr_dir.is_dir():
+            raise FileNotFoundError(f"Missing LR folder: '{self.lr_dir}'.")
+        if not self.hr_dir.is_dir():
+            raise FileNotFoundError(f"Missing HR folder: '{self.hr_dir}'.")
+
+        lr_files = sorted([p for p in self.lr_dir.iterdir() if p.is_file()])
+        self.pairs = []
+        for lr_path in lr_files:
+            hr_path = self.hr_dir / lr_path.name
+            if not hr_path.is_file():
+                raise FileNotFoundError(
+                    f"Missing HR counterpart for '{lr_path.name}' in '{self.hr_dir}'."
+                )
+            self.pairs.append((lr_path, hr_path))
+
+        if len(self.pairs) == 0:
+            raise RuntimeError(
+                f"No paired files found in '{self.lr_dir}' and '{self.hr_dir}'."
+            )
+
+    def __len__(self):
+        return len(self.pairs)
+
+    @staticmethod
+    def _load_array(path):
+        suffix = path.suffix.lower()
+        if suffix == ".npy":
+            arr = np.load(path)
+        elif suffix == ".npz":
+            with np.load(path) as z:
+                arr = z[list(z.files)[0]]
+        elif suffix in {".tif", ".tiff"}:
+            with rasterio.open(path) as src:
+                arr = src.read()
+                arr = np.moveaxis(arr, 0, -1)  # CHW -> HWC for unified conversion below
+        else:
+            arr = np.array(Image.open(path))
+        return arr
+
+    @staticmethod
+    def _to_chw_tensor(arr):
+        if arr.ndim == 2:
+            arr = arr[:, :, None]
+        if arr.ndim != 3:
+            raise ValueError(f"Expected 2D/3D array, got shape {arr.shape}.")
+
+        # Heuristic: if first dim is tiny and later dims are spatial, treat as CHW already.
+        if not (arr.shape[0] <= 16 and arr.shape[1] > 16 and arr.shape[2] > 16):
+            arr = np.transpose(arr, (2, 0, 1))  # HWC -> CHW
+
+        return torch.from_numpy(arr.astype(np.float32))
+
+    def __getitem__(self, idx):
+        lr_path, hr_path = self.pairs[idx]
+        lr = self._to_chw_tensor(self._load_array(lr_path))
+        hr = self._to_chw_tensor(self._load_array(hr_path))
+        lr = self.normalizer.normalize(lr)
+        hr = self.normalizer.normalize(hr)
+
+        return {
+            "LR": lr,
+            "HR": hr,
+            "filename": lr_path.name,
+        }

--- a/tests/test_data/test_dataset_selector.py
+++ b/tests/test_data/test_dataset_selector.py
@@ -154,6 +154,21 @@ class _StubWorldWideDataset(Dataset):
         return self._data[idx]
 
 
+class _StubLRHRFolderDataset(Dataset):
+    created_args = []
+
+    def __init__(self, root_folder, phase, **kwargs):
+        self.__class__.created_args.append((root_folder, phase, kwargs))
+        self._data = torch.arange(3, dtype=torch.float32)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __getitem__(self, idx):
+        value = self._data[idx]
+        return {"LR": value, "HR": value + 1, "filename": f"{idx}.npy"}
+
+
 def _install_module(monkeypatch, name, is_package=False, **attrs):
     module = types.ModuleType(name)
     if is_package:
@@ -253,6 +268,35 @@ def test_select_dataset_sisr_ww_branch(monkeypatch):
     assert len(_StubWorldWideDataset.created_kwargs) == 2
     assert _StubWorldWideDataset.created_kwargs[0]["split"] == "train"
     assert _StubWorldWideDataset.created_kwargs[1]["split"] == "val"
+
+
+def test_select_dataset_lrhr_folder_branch(monkeypatch):
+    _StubLRHRFolderDataset.created_args.clear()
+    _install_module(monkeypatch, "opensr_srgan.data.lrhr_folder", is_package=True)
+    _install_module(
+        monkeypatch,
+        "opensr_srgan.data.lrhr_folder.lrhr_folder_dataset",
+        LRHRFolderDataset=_StubLRHRFolderDataset,
+    )
+
+    config = _make_config(
+        dataset_type="LRHRFolderDataset",
+        dataset_root="/tmp/my_dataset_root",
+        train_batch_size=2,
+        val_batch_size=2,
+        num_workers=0,
+    )
+
+    datamodule = dataset_selector.select_dataset(config)
+    train_loader = datamodule.train_dataloader()
+    train_batch = next(iter(train_loader))
+
+    assert _StubLRHRFolderDataset.created_args == [
+        ("/tmp/my_dataset_root", "train", {"normalization": "identity"}),
+        ("/tmp/my_dataset_root", "val", {"normalization": "identity"}),
+    ]
+    assert isinstance(train_batch, (list, tuple))
+    assert len(train_batch) == 2
 
 
 def test_dataset_selector_module_main_guard(monkeypatch):

--- a/tests/test_data/test_lrhr_folder_dataset.py
+++ b/tests/test_data/test_lrhr_folder_dataset.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from opensr_srgan.data.lrhr_folder.lrhr_folder_dataset import LRHRFolderDataset
+
+
+def _write_pair(root: Path, phase: str, name: str, lr_shape=(8, 8, 3), hr_shape=(16, 16, 3)):
+    (root / phase / "LR").mkdir(parents=True, exist_ok=True)
+    (root / phase / "HR").mkdir(parents=True, exist_ok=True)
+    np.save(root / phase / "LR" / name, np.zeros(lr_shape, dtype=np.float32))
+    np.save(root / phase / "HR" / name, np.ones(hr_shape, dtype=np.float32))
+
+
+def test_lrhr_folder_dataset_reads_phase_pairs(tmp_path):
+    _write_pair(tmp_path, "train", "a.npy")
+    _write_pair(tmp_path, "train", "b.npy")
+    _write_pair(tmp_path, "val", "v.npy")
+    _write_pair(tmp_path, "test", "t.npy")
+
+    ds = LRHRFolderDataset(root_folder=tmp_path, phase="train")
+    assert len(ds) == 2
+
+    sample = ds[0]
+    assert set(sample.keys()) == {"LR", "HR", "filename"}
+    assert isinstance(sample["LR"], torch.Tensor)
+    assert isinstance(sample["HR"], torch.Tensor)
+    assert sample["LR"].shape == (3, 8, 8)
+    assert sample["HR"].shape == (3, 16, 16)
+
+
+def test_lrhr_folder_dataset_invalid_phase_raises(tmp_path):
+    with pytest.raises(ValueError):
+        LRHRFolderDataset(root_folder=tmp_path, phase="dev")
+
+
+def test_lrhr_folder_dataset_missing_pair_raises(tmp_path):
+    (tmp_path / "train" / "LR").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "train" / "HR").mkdir(parents=True, exist_ok=True)
+    np.save(tmp_path / "train" / "LR" / "only_lr.npy", np.zeros((8, 8, 1), dtype=np.float32))
+
+    with pytest.raises(FileNotFoundError):
+        LRHRFolderDataset(root_folder=tmp_path, phase="train")
+
+
+def test_lrhr_folder_dataset_applies_normalization(tmp_path):
+    (tmp_path / "train" / "LR").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "train" / "HR").mkdir(parents=True, exist_ok=True)
+    np.save(
+        tmp_path / "train" / "LR" / "x.npy",
+        np.full((4, 4, 1), 10000.0, dtype=np.float32),
+    )
+    np.save(
+        tmp_path / "train" / "HR" / "x.npy",
+        np.full((8, 8, 1), 10000.0, dtype=np.float32),
+    )
+
+    ds = LRHRFolderDataset(
+        root_folder=tmp_path,
+        phase="train",
+        normalization="normalise_10k",
+    )
+    sample = ds[0]
+
+    assert torch.allclose(sample["LR"], torch.ones_like(sample["LR"]))
+    assert torch.allclose(sample["HR"], torch.ones_like(sample["HR"]))


### PR DESCRIPTION
I wanted to use a different dataset folder structure than the current version supports, so I added a new Dataset.

The new `LRHRFolderDataset` supports the traditional LR/HR folder structure, it's wired through normalizer, dataset selector, and config files.
The expected structure is as such:

```
    root_folder/
      train/
        LR/
          image_001.npy
          image_002.npy
        HR/
          image_001.npy
          image_002.npy
      val/
        LR/
        HR/
      test/
        LR/
        HR/
```

I also added tests for classic and edge cases (Passing).