### PR TITLE
Add deployment helpers and core functionalities for SRGAN HPC

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,56 @@
+# SRGAN HPC Launcher
+
+This directory contains an installable Slurm launcher for running `opensr-srgan` over `cubo`-staged Sentinel-2 cutouts.
+
+## What it does
+
+- stages Sentinel-2 cutouts with `cubo`
+- submits single-patch, grid, or AOI shapefile runs through `sbatch`
+- runs SRGAN RGB-NIR, SRGAN SWIR, or both
+- optionally stacks RGB-NIR and SWIR outputs into one 10-band GeoTIFF
+- writes manifests, logs, metadata, and outputs into one run directory
+
+## Install
+
+```bash
+pip install -e .[hpc]
+```
+
+This exposes the `srgan-hpc` CLI.
+
+## Example commands
+
+```bash
+srgan-hpc validate-config --config deployment/configs/runtime.default.yaml
+
+srgan-hpc submit patch \
+  --config deployment/configs/runtime.default.yaml \
+  --lat 52.5200 \
+  --lon 13.4050 \
+  --start-date 2025-07-01 \
+  --end-date 2025-07-03 \
+  --dry-run
+
+srgan-hpc submit grid \
+  --config deployment/configs/runtime.default.yaml \
+  --lat1 52.3 --lon1 12.9 \
+  --lat2 52.7 --lon2 13.8 \
+  --start-date 2025-07-01 \
+  --end-date 2025-07-03 \
+  --dry-run
+
+srgan-hpc submit aoi \
+  --config deployment/configs/runtime.default.yaml \
+  --aoi-path /data/berlin_aoi \
+  --start-date 2025-07-01 \
+  --end-date 2025-07-03 \
+  --dry-run
+```
+
+## Runtime Modes
+
+- `mode: rgbnir` stages `B04, B03, B02, B08` at 10 m and runs the RGB-NIR preset.
+- `mode: swir` stages `B05, B06, B07, B8A, B11, B12` at 20 m and runs the SWIR preset.
+- `mode: fused` runs both and writes `fused_sr.tif` with band order `B04, B03, B02, B08, B05, B06, B07, B8A, B11, B12`.
+
+AOI submission accepts either a `.shp` file or a directory containing exactly one `.shp`; sidecar files like `.shx`, `.dbf`, and `.prj` must sit alongside it.

--- a/deployment/__init__.py
+++ b/deployment/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment helpers for opensr-model."""

--- a/deployment/configs/runtime.a100.example.yaml
+++ b/deployment/configs/runtime.a100.example.yaml
@@ -1,16 +1,26 @@
+# A100 cluster example:
+# 1. Copy this file to a new name before editing it.
+# 2. Replace module, conda_env, partition, account, qos, and gres values with your cluster's names.
+# 3. Validate before submitting:
+#    srgan-hpc validate-config --config deployment/configs/my-a100.yaml
+
+# Names the run and chooses where run folders, manifests, logs, and outputs are written.
 project_name: "srgan"
 output_root: "../../runs"
 mode: "fused"
 
+# Runtime setup for worker jobs. These example values assume a CUDA module and srgan conda env.
 environment:
   python_executable: "python"
   modules: ["cuda/12.1"]
   conda_env: "srgan"
 
+# Optional AOI input for `srgan-hpc submit aoi`. Leave null for patch/grid runs.
 aoi:
   path: null
   layer: null
 
+# Sentinel-2 download and cutout settings. edge_size is pixels; larger values use more memory.
 staging:
   collection: "sentinel-2-l2a"
   image_index: 0
@@ -22,6 +32,7 @@ staging:
   retry_on_rate_limit: true
   rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
 
+# RGB/NIR model input. Change model paths only when using your own checkpoint.
 rgbnir:
   bands: ["B04", "B03", "B02", "B08"]
   resolution: 10
@@ -32,6 +43,7 @@ rgbnir:
     checkpoint_path: null
     cache_dir: null
 
+# SWIR model input. These defaults match the bundled SWIR preset.
 swir:
   bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
   resolution: 20
@@ -42,6 +54,7 @@ swir:
     checkpoint_path: null
     cache_dir: null
 
+# Inference tiling. A100 GPUs can usually handle a larger batch_size than smaller GPUs.
 inference:
   window_size: [128, 128]
   batch_size: 16
@@ -50,6 +63,7 @@ inference:
   gpus: 0
   save_preview: false
 
+# Slurm job resources. Update these to match your cluster's GPU partition policy.
 slurm:
   partition: "gpu"
   gpu_type: "a100"

--- a/deployment/configs/runtime.a100.example.yaml
+++ b/deployment/configs/runtime.a100.example.yaml
@@ -1,0 +1,63 @@
+project_name: "srgan"
+output_root: "../../runs"
+mode: "fused"
+
+environment:
+  python_executable: "python"
+  modules: ["cuda/12.1"]
+  conda_env: "srgan"
+
+aoi:
+  path: null
+  layer: null
+
+staging:
+  collection: "sentinel-2-l2a"
+  image_index: 0
+  edge_size: 4096
+  nodata: 0
+  output_dtype: "uint16"
+  compression: "deflate"
+  overlap_meters: 128.0
+  retry_on_rate_limit: true
+  rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
+
+rgbnir:
+  bands: ["B04", "B03", "B02", "B08"]
+  resolution: 10
+  factor: 4
+  model:
+    preset: "RGB-NIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+swir:
+  bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
+  resolution: 20
+  factor: 8
+  model:
+    preset: "SWIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+inference:
+  window_size: [128, 128]
+  batch_size: 16
+  overlap: 12
+  eliminate_border_px: 2
+  gpus: 0
+  save_preview: false
+
+slurm:
+  partition: "gpu"
+  gpu_type: "a100"
+  gpus: 1
+  gres: null
+  cpus_per_task: 16
+  mem_gb: 192
+  time: "02:00:00"
+  account: null
+  qos: null
+  extra_args: []

--- a/deployment/configs/runtime.default.yaml
+++ b/deployment/configs/runtime.default.yaml
@@ -1,16 +1,27 @@
+# Beginner setup:
+# 1. Copy this file to a new name, for example my-cluster.yaml.
+# 2. Edit output_root, environment, and slurm for your machine or HPC cluster.
+# 3. Keep mode as "fused" unless you only want one product.
+# 4. Run:
+#    srgan-hpc validate-config --config deployment/configs/my-cluster.yaml
+
+# Names the run and chooses where run folders, manifests, logs, and outputs are written.
 project_name: "srgan"
 output_root: "../../runs"
 mode: "fused"
 
+# Runtime setup for worker jobs. Use modules/conda_env only if your cluster requires them.
 environment:
   python_executable: "python"
   modules: []
   conda_env: null
 
+# Optional AOI input for `srgan-hpc submit aoi`. Leave null for patch/grid runs.
 aoi:
   path: null
   layer: null
 
+# Sentinel-2 download and cutout settings. edge_size is pixels; larger values use more memory.
 staging:
   collection: "sentinel-2-l2a"
   image_index: 0
@@ -22,6 +33,7 @@ staging:
   retry_on_rate_limit: true
   rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
 
+# RGB/NIR model input. Change model paths only when using your own checkpoint.
 rgbnir:
   bands: ["B04", "B03", "B02", "B08"]
   resolution: 10
@@ -32,6 +44,7 @@ rgbnir:
     checkpoint_path: null
     cache_dir: null
 
+# SWIR model input. These defaults match the bundled SWIR preset.
 swir:
   bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
   resolution: 20
@@ -42,6 +55,7 @@ swir:
     checkpoint_path: null
     cache_dir: null
 
+# Inference tiling. Lower batch_size if the GPU runs out of memory.
 inference:
   window_size: [128, 128]
   batch_size: 16
@@ -50,6 +64,7 @@ inference:
   gpus: 0
   save_preview: false
 
+# Slurm job resources. Ask your cluster docs/admin for partition, account, qos, and gres names.
 slurm:
   partition: null
   gpu_type: null

--- a/deployment/configs/runtime.default.yaml
+++ b/deployment/configs/runtime.default.yaml
@@ -1,0 +1,63 @@
+project_name: "srgan"
+output_root: "../../runs"
+mode: "fused"
+
+environment:
+  python_executable: "python"
+  modules: []
+  conda_env: null
+
+aoi:
+  path: null
+  layer: null
+
+staging:
+  collection: "sentinel-2-l2a"
+  image_index: 0
+  edge_size: 4096
+  nodata: 0
+  output_dtype: "uint16"
+  compression: "deflate"
+  overlap_meters: 128.0
+  retry_on_rate_limit: true
+  rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
+
+rgbnir:
+  bands: ["B04", "B03", "B02", "B08"]
+  resolution: 10
+  factor: 4
+  model:
+    preset: "RGB-NIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+swir:
+  bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
+  resolution: 20
+  factor: 8
+  model:
+    preset: "SWIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+inference:
+  window_size: [128, 128]
+  batch_size: 16
+  overlap: 12
+  eliminate_border_px: 2
+  gpus: 0
+  save_preview: false
+
+slurm:
+  partition: null
+  gpu_type: null
+  gpus: 1
+  gres: null
+  cpus_per_task: 8
+  mem_gb: 128
+  time: "01:00:00"
+  account: null
+  qos: null
+  extra_args: []

--- a/deployment/configs/runtime.test.yaml
+++ b/deployment/configs/runtime.test.yaml
@@ -1,0 +1,63 @@
+project_name: "srgan_test"
+output_root: "../../runs"
+mode: "fused"
+
+environment:
+  python_executable: "python"
+  modules: []
+  conda_env: null
+
+aoi:
+  path: null
+  layer: null
+
+staging:
+  collection: "sentinel-2-l2a"
+  image_index: 0
+  edge_size: 512
+  nodata: 0
+  output_dtype: "uint16"
+  compression: "deflate"
+  overlap_meters: 64.0
+  retry_on_rate_limit: true
+  rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
+
+rgbnir:
+  bands: ["B04", "B03", "B02", "B08"]
+  resolution: 10
+  factor: 4
+  model:
+    preset: "RGB-NIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+swir:
+  bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
+  resolution: 20
+  factor: 8
+  model:
+    preset: "SWIR"
+    config_path: null
+    checkpoint_path: null
+    cache_dir: null
+
+inference:
+  window_size: [128, 128]
+  batch_size: 1
+  overlap: 12
+  eliminate_border_px: 2
+  gpus: 0
+  save_preview: false
+
+slurm:
+  partition: null
+  gpu_type: null
+  gpus: 1
+  gres: null
+  cpus_per_task: 8
+  mem_gb: 64
+  time: "01:00:00"
+  account: null
+  qos: null
+  extra_args: []

--- a/deployment/configs/runtime.test.yaml
+++ b/deployment/configs/runtime.test.yaml
@@ -1,16 +1,26 @@
+# Small local/test config:
+# 1. Use this for quick dry-runs and smoke tests, not production inference.
+# 2. It keeps edge_size and batch_size small so failures are faster to debug.
+# 3. Run:
+#    srgan-hpc validate-config --config deployment/configs/runtime.test.yaml
+
+# Names the run and chooses where run folders, manifests, logs, and outputs are written.
 project_name: "srgan_test"
 output_root: "../../runs"
 mode: "fused"
 
+# Runtime setup for worker jobs. Use modules/conda_env only if your cluster requires them.
 environment:
   python_executable: "python"
   modules: []
   conda_env: null
 
+# Optional AOI input for `srgan-hpc submit aoi`. Leave null for patch/grid runs.
 aoi:
   path: null
   layer: null
 
+# Sentinel-2 download and cutout settings. edge_size is intentionally small here.
 staging:
   collection: "sentinel-2-l2a"
   image_index: 0
@@ -22,6 +32,7 @@ staging:
   retry_on_rate_limit: true
   rate_limit_retry_delays_seconds: [15, 30, 60, 120, 120, 120]
 
+# RGB/NIR model input. Change model paths only when using your own checkpoint.
 rgbnir:
   bands: ["B04", "B03", "B02", "B08"]
   resolution: 10
@@ -32,6 +43,7 @@ rgbnir:
     checkpoint_path: null
     cache_dir: null
 
+# SWIR model input. These defaults match the bundled SWIR preset.
 swir:
   bands: ["B05", "B06", "B07", "B8A", "B11", "B12"]
   resolution: 20
@@ -42,6 +54,7 @@ swir:
     checkpoint_path: null
     cache_dir: null
 
+# Inference tiling. batch_size is intentionally 1 to keep this config lightweight.
 inference:
   window_size: [128, 128]
   batch_size: 1
@@ -50,6 +63,7 @@ inference:
   gpus: 0
   save_preview: false
 
+# Slurm job resources. Ask your cluster docs/admin for partition, account, qos, and gres names.
 slurm:
   partition: null
   gpu_type: null

--- a/deployment/srgan_hpc/__init__.py
+++ b/deployment/srgan_hpc/__init__.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+
+def get_version() -> str:
+    try:
+        return importlib_metadata.version("opensr-srgan")
+    except importlib_metadata.PackageNotFoundError:  # pragma: no cover
+        return "unknown"
+
+
+def bundled_slurm_entrypoint() -> Path:
+    return Path(__file__).resolve().parent / "slurm" / "slurm_task_entrypoint.sh"
+
+
+__version__ = get_version()

--- a/deployment/srgan_hpc/aoi.py
+++ b/deployment/srgan_hpc/aoi.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import shapefile
+from pyproj import CRS, Transformer
+from shapely.geometry import box, shape
+from shapely.geometry.base import BaseGeometry
+from shapely.ops import transform, unary_union
+
+from deployment.srgan_hpc.patching import Patch, build_patches, meters_to_lat_deg, meters_to_lon_deg
+
+
+@dataclass(frozen=True, slots=True)
+class AoiSelection:
+    aoi_path: Path
+    aoi_layer: str | None
+    geometry: BaseGeometry
+    patches: list[Patch]
+
+
+def resolve_aoi_source_path(path: str | Path) -> Path:
+    source_path = Path(path).expanduser().resolve()
+    if not source_path.exists():
+        raise FileNotFoundError(f"AOI path not found: {source_path}")
+
+    if source_path.is_dir():
+        candidates = sorted(candidate for candidate in source_path.iterdir() if candidate.suffix.lower() == ".shp")
+        if not candidates:
+            raise ValueError(f"No .shp file found in AOI directory: {source_path}")
+        if len(candidates) > 1:
+            raise ValueError(f"Expected exactly one .shp file in AOI directory: {source_path}")
+        return candidates[0].resolve()
+
+    if source_path.suffix.lower() != ".shp":
+        raise ValueError(f"AOI path must be a .shp file or a directory containing one: {source_path}")
+    return source_path
+
+
+def _load_source_crs(shp_path: Path) -> CRS:
+    prj_path = shp_path.with_suffix(".prj")
+    if not prj_path.exists():
+        raise ValueError(f"AOI shapefile is missing .prj sidecar: {prj_path}")
+    prj_text = prj_path.read_text(encoding="utf-8").strip()
+    if not prj_text:
+        raise ValueError(f"AOI shapefile has an empty .prj sidecar: {prj_path}")
+    return CRS.from_user_input(prj_text)
+
+
+def load_aoi_geometry(path: str | Path) -> tuple[Path, BaseGeometry]:
+    shp_path = resolve_aoi_source_path(path)
+    source_crs = _load_source_crs(shp_path)
+
+    reader = shapefile.Reader(str(shp_path))
+    try:
+        geometries: list[BaseGeometry] = []
+        for record in reader.shapeRecords():
+            geom = shape(record.shape.__geo_interface__)
+            if geom.is_empty:
+                continue
+            if geom.geom_type not in {"Polygon", "MultiPolygon"}:
+                raise ValueError("AOI shapefile must contain polygon geometries")
+            geometries.append(geom)
+    finally:
+        reader.close()
+
+    if not geometries:
+        raise ValueError(f"AOI shapefile does not contain any polygon geometries: {shp_path}")
+
+    geometry = unary_union(geometries)
+    if geometry.is_empty:
+        raise ValueError(f"AOI shapefile geometry is empty after union: {shp_path}")
+
+    if source_crs != CRS.from_epsg(4326):
+        transformer = Transformer.from_crs(source_crs, CRS.from_epsg(4326), always_xy=True)
+        geometry = transform(transformer.transform, geometry)
+
+    if geometry.is_empty:
+        raise ValueError(f"AOI shapefile geometry is empty after reprojection: {shp_path}")
+    return shp_path, geometry
+
+
+def patch_footprint(patch: Patch, resolution_m: float) -> BaseGeometry:
+    patch_size_m = patch.edge_size * resolution_m
+    half_lat = meters_to_lat_deg(patch_size_m) / 2.0
+    half_lon = meters_to_lon_deg(patch_size_m, patch.latitude) / 2.0
+    return box(
+        patch.longitude - half_lon,
+        patch.latitude - half_lat,
+        patch.longitude + half_lon,
+        patch.latitude + half_lat,
+    )
+
+
+def select_aoi_patches(
+    *,
+    aoi_path: str | Path,
+    aoi_layer: str | None,
+    edge_size: int,
+    resolution_m: float,
+    overlap_meters: float,
+) -> AoiSelection:
+    resolved_path, geometry = load_aoi_geometry(aoi_path)
+    lat_min, lon_min, lat_max, lon_max = geometry.bounds[1], geometry.bounds[0], geometry.bounds[3], geometry.bounds[2]
+    patches = build_patches(lat_min, lon_min, lat_max, lon_max, edge_size, resolution_m, overlap_meters)
+    selected = [patch for patch in patches if patch_footprint(patch, resolution_m).intersects(geometry)]
+    if not selected:
+        raise ValueError(f"No SR cutouts intersect the AOI geometry: {resolved_path}")
+    return AoiSelection(aoi_path=resolved_path, aoi_layer=aoi_layer, geometry=geometry, patches=selected)

--- a/deployment/srgan_hpc/checkpoint.py
+++ b/deployment/srgan_hpc/checkpoint.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from pathlib import Path
+
+
+def resolve_checkpoint_path(configured_path: str | None) -> Path | None:
+    if configured_path is None:
+        return None
+    path = Path(configured_path).expanduser().resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {path}")
+    return path
+
+
+def sha256sum(path: Path) -> str:
+    digest = sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/deployment/srgan_hpc/cli.py
+++ b/deployment/srgan_hpc/cli.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from deployment.srgan_hpc import bundled_slurm_entrypoint
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="srgan-hpc")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate-config")
+    validate_parser.add_argument("--config", required=True)
+
+    submit_parser = subparsers.add_parser("submit")
+    submit_subparsers = submit_parser.add_subparsers(dest="submit_command", required=True)
+
+    patch_parser = submit_subparsers.add_parser("patch")
+    _add_submit_common_args(patch_parser)
+    patch_parser.add_argument("--lat", type=float, required=True)
+    patch_parser.add_argument("--lon", type=float, required=True)
+
+    grid_parser = submit_subparsers.add_parser("grid")
+    _add_submit_common_args(grid_parser)
+    grid_parser.add_argument("--lat1", type=float, required=True)
+    grid_parser.add_argument("--lon1", type=float, required=True)
+    grid_parser.add_argument("--lat2", type=float, required=True)
+    grid_parser.add_argument("--lon2", type=float, required=True)
+
+    aoi_parser = submit_subparsers.add_parser("aoi")
+    _add_submit_common_args(aoi_parser)
+    aoi_parser.add_argument("--aoi-path")
+    aoi_parser.add_argument("--layer")
+
+    run_parser = subparsers.add_parser("run")
+    run_subparsers = run_parser.add_subparsers(dest="run_command", required=True)
+    task_parser = run_subparsers.add_parser("task")
+    task_parser.add_argument("--manifest", required=True)
+    task_parser.add_argument("--task-index", type=int)
+
+    collect_parser = subparsers.add_parser("collect")
+    collect_parser.add_argument("--run-dir", required=True)
+    collect_parser.add_argument("--dest")
+
+    status_parser = subparsers.add_parser("status")
+    status_parser.add_argument("--run-dir", required=True)
+
+    return parser
+
+
+def _add_submit_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--start-date", required=True)
+    parser.add_argument("--end-date", required=True)
+    parser.add_argument("--script-path")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--verbose", action="store_true")
+
+
+def _resolve_script_path(script_path: str | None) -> Path:
+    if script_path is None:
+        return bundled_slurm_entrypoint().resolve()
+    return Path(script_path).expanduser().resolve()
+
+
+def _log_multi_cutout_info(logger, patch_count: int, source_name: str) -> None:
+    if patch_count <= 1:
+        return
+    logger.info(
+        "%s uses multiple cubo cutouts (%d); cutouts overlap via staging.overlap_meters, "
+        "but overlapping SR outputs are not reconciled after inference, so downstream mosaics may show seams "
+        "at cutout boundaries",
+        source_name,
+        patch_count,
+    )
+
+
+def _handle_validate(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.config import load_runtime_config, patch_resolution
+
+    config = load_runtime_config(args.config)
+    print(f"Configuration valid: {config.config_path}")
+    return 0
+
+
+def _handle_submit_patch(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.config import load_runtime_config
+    from deployment.srgan_hpc.logging_utils import configure_logging
+    from deployment.srgan_hpc.patching import Patch
+    from deployment.srgan_hpc.submit import submit_patch_run
+
+    logger = configure_logging(verbose=args.verbose)
+    config = load_runtime_config(args.config)
+    patch = Patch(
+        patch_id="patch_000001",
+        latitude=args.lat,
+        longitude=args.lon,
+        edge_size=config.staging.edge_size,
+        row_index=0,
+        row_count=1,
+        column_index=0,
+        column_count=1,
+    )
+    run_id, run_dir, submission = submit_patch_run(
+        config=config,
+        patch=patch,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        script_path=_resolve_script_path(args.script_path),
+        dry_run=args.dry_run,
+    )
+    logger.info("submitted patch run_id=%s run_dir=%s", run_id, run_dir)
+    print(json.dumps({"run_id": run_id, "run_dir": str(run_dir), "submission": submission}, indent=2))
+    return 0
+
+
+def _handle_submit_grid(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.config import load_runtime_config
+    from deployment.srgan_hpc.logging_utils import configure_logging
+    from deployment.srgan_hpc.patching import build_patches
+    from deployment.srgan_hpc.submit import submit_grid_run
+
+    logger = configure_logging(verbose=args.verbose)
+    config = load_runtime_config(args.config)
+    patches = build_patches(
+        args.lat1,
+        args.lon1,
+        args.lat2,
+        args.lon2,
+        config.staging.edge_size,
+        float(patch_resolution(config)),
+        config.staging.overlap_meters,
+    )
+    _log_multi_cutout_info(logger, len(patches), "grid request")
+    run_id, run_dir, submission = submit_grid_run(
+        config=config,
+        patches=patches,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        script_path=_resolve_script_path(args.script_path),
+        dry_run=args.dry_run,
+    )
+    logger.info("submitted grid run_id=%s run_dir=%s patches=%d", run_id, run_dir, len(patches))
+    print(json.dumps({"run_id": run_id, "run_dir": str(run_dir), "patches": len(patches), "submission": submission}, indent=2))
+    return 0
+
+
+def _handle_submit_aoi(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.aoi import select_aoi_patches
+    from deployment.srgan_hpc.config import load_runtime_config, patch_resolution
+    from deployment.srgan_hpc.logging_utils import configure_logging
+    from deployment.srgan_hpc.submit import submit_aoi_run
+
+    logger = configure_logging(verbose=args.verbose)
+    config = load_runtime_config(args.config)
+    aoi_path = args.aoi_path or config.aoi.path
+    if aoi_path is None:
+        raise ValueError("AOI path must be provided via --aoi-path or config.aoi.path")
+    aoi_layer = args.layer if args.layer is not None else config.aoi.layer
+    selection = select_aoi_patches(
+        aoi_path=aoi_path,
+        aoi_layer=aoi_layer,
+        edge_size=config.staging.edge_size,
+        resolution_m=float(patch_resolution(config)),
+        overlap_meters=config.staging.overlap_meters,
+    )
+    _log_multi_cutout_info(logger, len(selection.patches), "AOI request")
+    run_id, run_dir, submission = submit_aoi_run(
+        config=config,
+        patches=selection.patches,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        script_path=_resolve_script_path(args.script_path),
+        aoi_path=selection.aoi_path,
+        aoi_layer=selection.aoi_layer,
+        dry_run=args.dry_run,
+    )
+    logger.info(
+        "submitted aoi run_id=%s run_dir=%s patches=%d aoi_path=%s",
+        run_id,
+        run_dir,
+        len(selection.patches),
+        selection.aoi_path,
+    )
+    payload = {
+        "run_id": run_id,
+        "run_dir": str(run_dir),
+        "patches": len(selection.patches),
+        "aoi_path": str(selection.aoi_path),
+        "submission": submission,
+    }
+    if selection.aoi_layer is not None:
+        payload["aoi_layer"] = selection.aoi_layer
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def _handle_run_task(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.logging_utils import configure_logging
+    from deployment.srgan_hpc.run_task import run_task
+
+    configure_logging()
+    task_index = args.task_index
+    if task_index is None and os.environ.get("SLURM_ARRAY_TASK_ID"):
+        task_index = int(os.environ["SLURM_ARRAY_TASK_ID"])
+    output = run_task(Path(args.manifest).resolve(), task_index=task_index)
+    print(output if output is not None else "skipped")
+    return 0
+
+
+def _handle_collect(args: argparse.Namespace) -> int:
+    from deployment.srgan_hpc.collect import collect_outputs
+
+    destination, copied = collect_outputs(Path(args.run_dir).resolve(), Path(args.dest).resolve() if args.dest else None)
+    print(json.dumps({"destination": str(destination), "copied": copied}, indent=2))
+    return 0
+
+
+def _handle_status(args: argparse.Namespace) -> int:
+    run_dir = Path(args.run_dir).resolve()
+    payload = {
+        "run_dir": str(run_dir),
+        "resolved_config": str(run_dir / "resolved_config.yaml"),
+        "run_manifest": str(run_dir / "run_manifest.yaml"),
+        "logs_dir": str(run_dir / "logs"),
+        "patch_count": len(list((run_dir / "patches").glob("patch_*"))) if (run_dir / "patches").exists() else 0,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "validate-config":
+        return _handle_validate(args)
+    if args.command == "submit" and args.submit_command == "patch":
+        return _handle_submit_patch(args)
+    if args.command == "submit" and args.submit_command == "grid":
+        return _handle_submit_grid(args)
+    if args.command == "submit" and args.submit_command == "aoi":
+        return _handle_submit_aoi(args)
+    if args.command == "run" and args.run_command == "task":
+        return _handle_run_task(args)
+    if args.command == "collect":
+        return _handle_collect(args)
+    if args.command == "status":
+        return _handle_status(args)
+    parser.error("Unhandled command")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployment/srgan_hpc/collect.py
+++ b/deployment/srgan_hpc/collect.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def collect_outputs(run_dir: Path, destination: Path | None = None) -> tuple[Path, int]:
+    destination = destination or run_dir / "collected"
+    destination.mkdir(parents=True, exist_ok=True)
+    copied = 0
+    for tif_path in run_dir.glob("patches/*/outputs/*.tif"):
+        shutil.copy2(tif_path, destination / tif_path.name)
+        copied += 1
+    return destination, copied

--- a/deployment/srgan_hpc/collect.py
+++ b/deployment/srgan_hpc/collect.py
@@ -8,7 +8,10 @@ def collect_outputs(run_dir: Path, destination: Path | None = None) -> tuple[Pat
     destination = destination or run_dir / "collected"
     destination.mkdir(parents=True, exist_ok=True)
     copied = 0
-    for tif_path in run_dir.glob("patches/*/outputs/*.tif"):
-        shutil.copy2(tif_path, destination / tif_path.name)
+    for tif_path in sorted(run_dir.glob("patches/*/outputs/*.tif")):
+        patch_id = tif_path.parent.parent.name
+        patch_destination = destination / patch_id
+        patch_destination.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(tif_path, patch_destination / tif_path.name)
         copied += 1
     return destination, copied

--- a/deployment/srgan_hpc/config.py
+++ b/deployment/srgan_hpc/config.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+
+DEFAULT_RATE_LIMIT_RETRY_DELAYS_SECONDS = [15, 30, 60, 120, 120, 120]
+RuntimeMode = Literal["rgbnir", "swir", "fused"]
+
+
+@dataclass(slots=True)
+class EnvironmentConfig:
+    python_executable: str = "python"
+    modules: list[str] = field(default_factory=list)
+    conda_env: str | None = None
+
+
+@dataclass(slots=True)
+class ModelSourceConfig:
+    preset: str | None
+    config_path: str | None = None
+    checkpoint_path: str | None = None
+    cache_dir: str | None = None
+
+
+@dataclass(slots=True)
+class ProductConfig:
+    bands: list[str]
+    resolution: int
+    factor: int
+    model: ModelSourceConfig
+
+
+@dataclass(slots=True)
+class AoiConfig:
+    path: str | None = None
+    layer: str | None = None
+
+
+@dataclass(slots=True)
+class StagingConfig:
+    collection: str = "sentinel-2-l2a"
+    image_index: int = 0
+    edge_size: int = 4096
+    nodata: int = 0
+    output_dtype: str = "uint16"
+    compression: str = "deflate"
+    overlap_meters: float = 128.0
+    retry_on_rate_limit: bool = True
+    rate_limit_retry_delays_seconds: list[int] = field(
+        default_factory=lambda: list(DEFAULT_RATE_LIMIT_RETRY_DELAYS_SECONDS)
+    )
+
+
+@dataclass(slots=True)
+class InferenceConfig:
+    window_size: tuple[int, int] = (128, 128)
+    batch_size: int = 16
+    overlap: int = 12
+    eliminate_border_px: int = 2
+    gpus: int | list[int] = 0
+    save_preview: bool = False
+
+
+@dataclass(slots=True)
+class SlurmConfig:
+    partition: str | None = None
+    gpu_type: str | None = None
+    gpus: int = 1
+    gres: str | None = None
+    cpus_per_task: int = 8
+    mem_gb: int = 128
+    time: str = "01:00:00"
+    account: str | None = None
+    qos: str | None = None
+    extra_args: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class RuntimeConfig:
+    project_name: str = "srgan"
+    output_root: Path = Path("runs")
+    mode: RuntimeMode = "fused"
+    environment: EnvironmentConfig = field(default_factory=EnvironmentConfig)
+    aoi: AoiConfig = field(default_factory=AoiConfig)
+    staging: StagingConfig = field(default_factory=StagingConfig)
+    inference: InferenceConfig = field(default_factory=InferenceConfig)
+    rgbnir: ProductConfig = field(
+        default_factory=lambda: ProductConfig(
+            bands=["B04", "B03", "B02", "B08"],
+            resolution=10,
+            factor=4,
+            model=ModelSourceConfig(preset="RGB-NIR"),
+        )
+    )
+    swir: ProductConfig = field(
+        default_factory=lambda: ProductConfig(
+            bands=["B05", "B06", "B07", "B8A", "B11", "B12"],
+            resolution=20,
+            factor=8,
+            model=ModelSourceConfig(preset="SWIR"),
+        )
+    )
+    slurm: SlurmConfig = field(default_factory=SlurmConfig)
+    config_path: Path | None = None
+
+
+def enabled_product_names(config: RuntimeConfig) -> list[str]:
+    if config.mode == "rgbnir":
+        return ["rgbnir"]
+    if config.mode == "swir":
+        return ["swir"]
+    return ["rgbnir", "swir"]
+
+
+def get_product_config(config: RuntimeConfig, product_name: str) -> ProductConfig:
+    if product_name == "rgbnir":
+        return config.rgbnir
+    if product_name == "swir":
+        return config.swir
+    raise ValueError(f"Unknown product: {product_name}")
+
+
+def patch_resolution(config: RuntimeConfig) -> int:
+    products = [get_product_config(config, name) for name in enabled_product_names(config)]
+    return min(product.resolution for product in products)
+
+
+def product_edge_size(config: RuntimeConfig, product: ProductConfig) -> int:
+    selected_resolution = patch_resolution(config)
+    edge_size = config.staging.edge_size * selected_resolution / product.resolution
+    rounded = int(round(edge_size))
+    if rounded <= 0 or abs(edge_size - rounded) > 1e-6:
+        raise ValueError(
+            "staging.edge_size must describe a whole-number cutout at every enabled product resolution"
+        )
+    return rounded
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at {path}, got {type(data).__name__}")
+    return data
+
+
+def _merge(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _model_source_from_mapping(data: dict[str, Any], default_preset: str) -> ModelSourceConfig:
+    return ModelSourceConfig(
+        preset=data.get("preset", default_preset),
+        config_path=data.get("config_path"),
+        checkpoint_path=data.get("checkpoint_path"),
+        cache_dir=data.get("cache_dir"),
+    )
+
+
+def _product_from_mapping(data: dict[str, Any], default: ProductConfig) -> ProductConfig:
+    model_data = data.get("model", {})
+    legacy_config_path = data.get("config_path")
+    legacy_checkpoint_path = data.get("checkpoint_path")
+    if legacy_config_path is not None or legacy_checkpoint_path is not None:
+        model_data = {
+            **model_data,
+            "config_path": legacy_config_path or model_data.get("config_path"),
+            "checkpoint_path": legacy_checkpoint_path or model_data.get("checkpoint_path"),
+        }
+    return ProductConfig(
+        bands=list(data.get("bands", default.bands)),
+        resolution=int(data.get("resolution", default.resolution)),
+        factor=int(data.get("factor", default.factor)),
+        model=_model_source_from_mapping(model_data, default.model.preset or ""),
+    )
+
+
+def _runtime_from_mapping(data: dict[str, Any]) -> RuntimeConfig:
+    defaults = RuntimeConfig()
+    environment = EnvironmentConfig(**data.get("environment", {}))
+    aoi = AoiConfig(**data.get("aoi", {}))
+    staging = StagingConfig(**data.get("staging", {}))
+    inference_data = dict(data.get("inference", {}))
+    if "window_size" in inference_data:
+        inference_data["window_size"] = tuple(inference_data["window_size"])
+    inference = InferenceConfig(**inference_data)
+    slurm = SlurmConfig(**data.get("slurm", {}))
+    return RuntimeConfig(
+        project_name=data.get("project_name", defaults.project_name),
+        output_root=Path(data.get("output_root", "runs")),
+        mode=data.get("mode", defaults.mode),
+        environment=environment,
+        aoi=aoi,
+        staging=staging,
+        inference=inference,
+        rgbnir=_product_from_mapping(data.get("rgbnir", {}), defaults.rgbnir),
+        swir=_product_from_mapping(data.get("swir", {}), defaults.swir),
+        slurm=slurm,
+    )
+
+
+def _resolve_optional_path(value: str | None, base_dir: Path, *, must_exist: bool = False) -> str | None:
+    if value is None:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        path = (base_dir / path).resolve()
+    else:
+        path = path.resolve()
+    if must_exist and not path.exists():
+        raise FileNotFoundError(f"Path not found: {path}")
+    return str(path)
+
+
+def _resolve_product_paths(product: ProductConfig, base_dir: Path) -> None:
+    product.model.config_path = _resolve_optional_path(product.model.config_path, base_dir, must_exist=True)
+    product.model.checkpoint_path = _resolve_optional_path(product.model.checkpoint_path, base_dir, must_exist=True)
+    product.model.cache_dir = _resolve_optional_path(product.model.cache_dir, base_dir)
+
+
+def load_runtime_config(
+    config_path: str | Path,
+    overrides: dict[str, Any] | None = None,
+) -> RuntimeConfig:
+    path = Path(config_path).expanduser().resolve()
+    data = _read_yaml(path)
+    if overrides:
+        data = _merge(data, overrides)
+    config = _runtime_from_mapping(data)
+    config.config_path = path
+    base_dir = path.parent
+
+    if not config.output_root.is_absolute():
+        config.output_root = (base_dir / config.output_root).resolve()
+
+    if config.aoi.path is not None:
+        config.aoi.path = _resolve_optional_path(config.aoi.path, base_dir)
+
+    _resolve_product_paths(config.rgbnir, base_dir)
+    _resolve_product_paths(config.swir, base_dir)
+    validate_runtime_config(config)
+    return config
+
+
+def validate_runtime_config(config: RuntimeConfig) -> None:
+    if config.mode not in {"rgbnir", "swir", "fused"}:
+        raise ValueError("mode must be one of: rgbnir, swir, fused")
+    if config.staging.edge_size <= 0:
+        raise ValueError("staging.edge_size must be positive")
+    if config.staging.overlap_meters < 0:
+        raise ValueError("staging.overlap_meters must be non-negative")
+    if any(delay <= 0 for delay in config.staging.rate_limit_retry_delays_seconds):
+        raise ValueError("staging.rate_limit_retry_delays_seconds must contain positive integers")
+    if len(config.inference.window_size) != 2 or min(config.inference.window_size) <= 0:
+        raise ValueError("inference.window_size must contain two positive integers")
+    if config.inference.batch_size <= 0:
+        raise ValueError("inference.batch_size must be positive")
+    if config.slurm.gpus < 0:
+        raise ValueError("slurm.gpus must be non-negative")
+    if config.slurm.mem_gb <= 0:
+        raise ValueError("slurm.mem_gb must be positive")
+    if config.slurm.cpus_per_task <= 0:
+        raise ValueError("slurm.cpus_per_task must be positive")
+    if config.aoi.path is not None and not Path(config.aoi.path).exists():
+        raise FileNotFoundError(f"AOI path not found: {config.aoi.path}")
+
+    for product_name in enabled_product_names(config):
+        product = get_product_config(config, product_name)
+        if product.resolution <= 0:
+            raise ValueError(f"{product_name}.resolution must be positive")
+        if product.factor <= 0:
+            raise ValueError(f"{product_name}.factor must be positive")
+        if not product.bands:
+            raise ValueError(f"{product_name}.bands must not be empty")
+        if product.model.preset is None and product.model.config_path is None:
+            raise ValueError(f"{product_name}.model must define a preset or config_path")
+        product_edge_size(config, product)
+
+
+def runtime_config_to_dict(config: RuntimeConfig) -> dict[str, Any]:
+    data = asdict(config)
+    data["output_root"] = str(config.output_root)
+    data["config_path"] = str(config.config_path) if config.config_path else None
+    data["inference"]["window_size"] = list(config.inference.window_size)
+    return data

--- a/deployment/srgan_hpc/inference.py
+++ b/deployment/srgan_hpc/inference.py
@@ -114,6 +114,6 @@ def run_inference(
 
     compressed_path = output_dir / product_output_name(product_name)
     LOGGER.info("compressing SR GeoTIFF product=%s input=%s output=%s", product_name, final_sr_path, compressed_path)
-    compress_geotiff(final_sr_path, compressed_path)
+    compress_geotiff(final_sr_path, compressed_path, band_names=product.bands)
     final_sr_path.unlink(missing_ok=True)
     return compressed_path

--- a/deployment/srgan_hpc/inference.py
+++ b/deployment/srgan_hpc/inference.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+import torch
+
+from deployment.srgan_hpc.config import InferenceConfig, ProductConfig
+from deployment.srgan_hpc.naming import product_output_name
+from deployment.srgan_hpc.raster import compress_geotiff
+
+
+LOGGER = logging.getLogger("srgan-hpc")
+
+
+def _build_runner(opensr_utils: Any, inference: InferenceConfig):
+    class ConfigurableLargeFileProcessing(opensr_utils.large_file_processing):
+        def __init__(self, *args: Any, batch_size: int, **kwargs: Any) -> None:
+            self._srgan_hpc_batch_size = batch_size
+            super().__init__(*args, **kwargs)
+
+        def create_datamodule(self) -> None:
+            from opensr_utils.data_utils.datamodule import PredictionDataModule
+
+            dm = PredictionDataModule(
+                input_type=self.input_type,
+                root=self.root,
+                windows=self.image_meta["image_windows"],
+                lr_file_dict=self.image_meta["lr_file_dict"],
+                prefetch_factor=2,
+                batch_size=self._srgan_hpc_batch_size,
+                num_workers=4,
+            )
+            dm.setup()
+            self._log(
+                f"Created PredictionDataModule with {len(dm.dataset)} patches "
+                f"(batch_size={self._srgan_hpc_batch_size})."
+            )
+            self.datamodule = dm
+
+    return ConfigurableLargeFileProcessing
+
+
+def load_srgan_model(product: ProductConfig):
+    from opensr_srgan import load_from_config, load_inference_model
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    map_location = torch.device(device)
+    if product.model.config_path is not None:
+        return load_from_config(
+            product.model.config_path,
+            product.model.checkpoint_path,
+            map_location=map_location,
+            mode="eval",
+        ).to(device), device
+    if product.model.preset is None:
+        raise ValueError("Product model source must define preset or config_path")
+    return load_inference_model(
+        product.model.preset,
+        cache_dir=product.model.cache_dir,
+        map_location=map_location,
+    ).to(device), device
+
+
+def run_inference(
+    *,
+    input_tif: Path,
+    output_dir: Path,
+    product_name: str,
+    product: ProductConfig,
+    inference: InferenceConfig,
+) -> Path:
+    try:
+        import opensr_utils
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "srgan-hpc inference requires opensr-utils. Install with `pip install \"opensr-srgan[hpc]\"`."
+        ) from exc
+
+    model, device = load_srgan_model(product)
+    LOGGER.info(
+        "running SRGAN product=%s input_tif=%s device=%s bands=%s factor=%s",
+        product_name,
+        input_tif,
+        device,
+        product.bands,
+        product.factor,
+    )
+    runner_cls = _build_runner(opensr_utils, inference)
+    runner = runner_cls(
+        root=str(input_tif),
+        model=model,
+        window_size=tuple(inference.window_size),
+        batch_size=inference.batch_size,
+        factor=product.factor,
+        overlap=inference.overlap,
+        eliminate_border_px=inference.eliminate_border_px,
+        device=device,
+        gpus=cast(Any, inference.gpus),
+        save_preview=inference.save_preview,
+        debug=False,
+    )
+    runner.start_super_resolution()
+
+    final_sr_path = getattr(runner, "final_sr_path", None)
+    if final_sr_path is None:
+        final_sr_path = output_dir / "sr.tif"
+    else:
+        final_sr_path = Path(final_sr_path)
+
+    if not final_sr_path.exists():
+        raise FileNotFoundError(f"Expected SR output at {final_sr_path}")
+
+    compressed_path = output_dir / product_output_name(product_name)
+    LOGGER.info("compressing SR GeoTIFF product=%s input=%s output=%s", product_name, final_sr_path, compressed_path)
+    compress_geotiff(final_sr_path, compressed_path)
+    final_sr_path.unlink(missing_ok=True)
+    return compressed_path

--- a/deployment/srgan_hpc/logging_utils.py
+++ b/deployment/srgan_hpc/logging_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+
+def configure_logging(log_path: Path | None = None, verbose: bool = False) -> logging.Logger:
+    logger = logging.getLogger("srgan-hpc")
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+    logger.handlers.clear()
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+    logger.addHandler(stream_handler)
+
+    if log_path is not None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_path, encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger

--- a/deployment/srgan_hpc/manifests.py
+++ b/deployment/srgan_hpc/manifests.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def new_run_id(project_name: str) -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    return f"{project_name}_{timestamp}"
+
+
+def write_yaml(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(payload, handle, sort_keys=False)
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)

--- a/deployment/srgan_hpc/metadata.py
+++ b/deployment/srgan_hpc/metadata.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+from deployment.srgan_hpc.manifests import write_json
+
+
+def write_software_metadata(path: Path, extra: dict[str, Any] | None = None) -> None:
+    payload: dict[str, Any] = {
+        "python_version": sys.version,
+        "platform": platform.platform(),
+    }
+    if extra:
+        payload.update(extra)
+    write_json(path, payload)

--- a/deployment/srgan_hpc/naming.py
+++ b/deployment/srgan_hpc/naming.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def patch_output_name(latitude: float, longitude: float) -> str:
+    return f"output_SR_image_{latitude:.6f}_{longitude:.6f}.tif"
+
+
+def product_output_name(product_name: str) -> str:
+    return f"{product_name}_sr.tif"
+
+
+def fused_output_name() -> str:
+    return "fused_sr.tif"
+
+
+def resolve_run_dir(output_root: Path, run_id: str) -> Path:
+    return output_root / run_id
+
+
+def patch_dir(run_dir: Path, patch_id: str) -> Path:
+    return run_dir / "patches" / patch_id

--- a/deployment/srgan_hpc/patching.py
+++ b/deployment/srgan_hpc/patching.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Patch:
+    patch_id: str
+    latitude: float
+    longitude: float
+    edge_size: int
+    row_index: int
+    row_count: int
+    column_index: int
+    column_count: int
+
+
+def meters_to_lat_deg(distance_m: float) -> float:
+    return distance_m / 111_320.0
+
+
+def meters_to_lon_deg(distance_m: float, latitude_deg: float) -> float:
+    meters_per_degree_lon = 111_320.0 * math.cos(math.radians(latitude_deg))
+    if meters_per_degree_lon <= 0:
+        raise ValueError(f"Cannot compute longitude degrees at latitude {latitude_deg:.6f}")
+    return distance_m / meters_per_degree_lon
+
+
+def clamp_center(suggested_center: float, min_value: float, max_value: float, half_extent: float) -> float:
+    lower_limit = min_value + half_extent
+    upper_limit = max_value - half_extent
+    if lower_limit > upper_limit:
+        return (min_value + max_value) / 2.0
+    return max(lower_limit, min(suggested_center, upper_limit))
+
+
+def compute_centers(min_value: float, max_value: float, patch_deg: float, step_deg: float) -> list[float]:
+    if patch_deg <= 0 or step_deg <= 0:
+        raise ValueError("patch_deg and step_deg must be positive")
+
+    half_extent = patch_deg / 2.0
+    span = max(0.0, max_value - min_value)
+
+    if span <= patch_deg:
+        center = (min_value + max_value) / 2.0
+        return [clamp_center(center, min_value, max_value, half_extent)]
+
+    count = int(math.ceil((span - patch_deg) / step_deg)) + 1
+    centers: list[float] = []
+    for index in range(count):
+        candidate = min_value + half_extent + index * step_deg
+        candidate = clamp_center(candidate, min_value, max_value, half_extent)
+        if centers and abs(candidate - centers[-1]) < 1e-12:
+            continue
+        centers.append(candidate)
+
+    if not centers:
+        centers.append(clamp_center((min_value + max_value) / 2.0, min_value, max_value, half_extent))
+
+    return centers
+
+
+def build_patches(
+    lat1: float,
+    lon1: float,
+    lat2: float,
+    lon2: float,
+    edge_size: int,
+    resolution_m: float,
+    overlap_meters: float,
+) -> list[Patch]:
+    lat_min, lat_max = sorted((lat1, lat2))
+    if abs(lon2 - lon1) > 180.0:
+        raise ValueError("Bounding boxes that cross the antimeridian are not supported")
+    lon_min, lon_max = sorted((lon1, lon2))
+
+    if edge_size <= 0:
+        raise ValueError("edge_size must be positive")
+    if resolution_m <= 0:
+        raise ValueError("resolution_m must be positive")
+
+    patch_size_m = edge_size * resolution_m
+    if overlap_meters >= patch_size_m:
+        raise ValueError("overlap_meters must be smaller than patch size")
+
+    patch_step_m = patch_size_m - overlap_meters
+    patch_lat_deg = meters_to_lat_deg(patch_size_m)
+    lat_step_deg = meters_to_lat_deg(patch_step_m)
+    lat_centers = compute_centers(lat_min, lat_max, patch_lat_deg, lat_step_deg)
+    lat_rows = len(lat_centers)
+
+    patches: list[Patch] = []
+    patch_number = 1
+    for row_index, lat_center in enumerate(lat_centers):
+        patch_lon_deg = meters_to_lon_deg(patch_size_m, lat_center)
+        lon_step_deg = meters_to_lon_deg(patch_step_m, lat_center)
+        lon_centers = compute_centers(lon_min, lon_max, patch_lon_deg, lon_step_deg)
+        lon_cols = len(lon_centers)
+        for column_index, lon_center in enumerate(lon_centers):
+            patches.append(
+                Patch(
+                    patch_id=f"patch_{patch_number:06d}",
+                    latitude=lat_center,
+                    longitude=lon_center,
+                    edge_size=edge_size,
+                    row_index=row_index,
+                    row_count=lat_rows,
+                    column_index=column_index,
+                    column_count=lon_cols,
+                )
+            )
+            patch_number += 1
+    return patches

--- a/deployment/srgan_hpc/raster.py
+++ b/deployment/srgan_hpc/raster.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import os
+import re
+from math import floor
+from pathlib import Path
+
+import numpy as np
+
+
+def ensure_proj_env() -> None:
+    if os.environ.get("PROJ_LIB"):
+        return
+
+    from pyproj import datadir
+
+    proj_dir = datadir.get_data_dir()
+    os.environ["PROJ_LIB"] = proj_dir
+    os.environ["PROJ_DATA"] = proj_dir
+
+
+def guess_utm_epsg(lat: float, lon: float) -> int:
+    lat = max(min(lat, 84.0), -80.0)
+    zone = int(floor((lon + 180.0) / 6.0)) + 1
+    return 32600 + zone if lat >= 0 else 32700 + zone
+
+
+def parse_epsg(text: str, lat: float, lon: float) -> int:
+    match = re.search(r"(\d{4,5})", text)
+    if match:
+        return int(match.group(1))
+    return guess_utm_epsg(lat, lon)
+
+
+def _as_scalar(value: object) -> float:
+    if hasattr(value, "compute"):
+        value = value.compute()
+    return float(value)
+
+
+def scale_to_uint16(data: np.ndarray) -> np.ndarray:
+    if data.dtype.kind == "f":
+        finite_mask = np.isfinite(data)
+        safe_data = np.where(finite_mask, data, 0.0)
+        if _as_scalar(safe_data.max()) <= 1.1:
+            safe_data = safe_data * 10000.0
+        return np.clip(safe_data, 0, 10000).astype("uint16")
+    return data.astype("uint16")
+
+
+def compute_centroid_lat_lon(tif_path: Path) -> tuple[float, float]:
+    import rasterio
+    from rasterio.warp import transform as warp_transform
+
+    with rasterio.open(tif_path) as src:
+        if src.crs is None:
+            raise ValueError(f"Dataset at {tif_path} lacks a CRS")
+        center_row = src.height / 2.0
+        center_col = src.width / 2.0
+        x, y = src.transform * (center_col, center_row)
+        transformed = warp_transform(src.crs, "EPSG:4326", [x], [y])
+        lon = transformed[0]
+        lat = transformed[1]
+        return float(lat[0]), float(lon[0])
+
+
+def compress_geotiff(src_path: Path, dest_path: Path) -> Path:
+    from rasterio.shutil import copy as rio_copy
+
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+    rio_copy(
+        src_path,
+        dest_path,
+        driver="GTiff",
+        COMPRESS="ZSTD",
+        ZSTD_LEVEL=22,
+        PREDICTOR=2,
+        TILED=True,
+        BLOCKXSIZE=512,
+        BLOCKYSIZE=512,
+        BIGTIFF="YES",
+        NUM_THREADS="ALL_CPUS",
+    )
+    return dest_path
+
+
+def stack_geotiffs(
+    *,
+    reference_path: Path,
+    secondary_path: Path,
+    output_path: Path,
+    band_names: list[str],
+) -> Path:
+    import rasterio
+    from rasterio.enums import Resampling
+    from rasterio.warp import reproject
+
+    with rasterio.open(reference_path) as ref, rasterio.open(secondary_path) as secondary:
+        profile = ref.profile.copy()
+        secondary_data = np.empty((secondary.count, ref.height, ref.width), dtype=ref.dtypes[0])
+        for band_index in range(secondary.count):
+            reproject(
+                source=rasterio.band(secondary, band_index + 1),
+                destination=secondary_data[band_index],
+                src_transform=secondary.transform,
+                src_crs=secondary.crs,
+                dst_transform=ref.transform,
+                dst_crs=ref.crs,
+                resampling=Resampling.bilinear,
+            )
+
+        reference_data = ref.read()
+        stacked = np.concatenate([reference_data, secondary_data], axis=0)
+        profile.update(count=stacked.shape[0], dtype=stacked.dtype, BIGTIFF="YES")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with rasterio.open(output_path, "w", **profile) as dst:
+            dst.write(stacked)
+            if len(band_names) == stacked.shape[0]:
+                for index, name in enumerate(band_names, start=1):
+                    dst.set_band_description(index, name)
+            dst.update_tags(band_names=",".join(band_names))
+    return output_path
+
+
+def raster_validity_stats(tif_path: Path) -> dict[str, int]:
+    import rasterio
+
+    with rasterio.open(tif_path) as src:
+        data = src.read(masked=True)
+
+    if data.size == 0:
+        return {"total_pixels": 0, "valid_pixels": 0, "nonzero_pixels": 0}
+
+    values = np.asarray(np.ma.getdata(data))
+    validity_mask = np.isfinite(values)
+    if np.ma.isMaskedArray(data):
+        validity_mask &= ~np.ma.getmaskarray(data)
+
+    total_pixels = int(values.shape[-2] * values.shape[-1])
+    valid_pixels = int(validity_mask.any(axis=0).sum())
+    nonzero_pixels = int((validity_mask & (values != 0)).any(axis=0).sum())
+    return {
+        "total_pixels": total_pixels,
+        "valid_pixels": valid_pixels,
+        "nonzero_pixels": nonzero_pixels,
+    }

--- a/deployment/srgan_hpc/raster.py
+++ b/deployment/srgan_hpc/raster.py
@@ -64,7 +64,14 @@ def compute_centroid_lat_lon(tif_path: Path) -> tuple[float, float]:
         return float(lat[0]), float(lon[0])
 
 
-def compress_geotiff(src_path: Path, dest_path: Path) -> Path:
+def _write_band_names(dataset, band_names: list[str]) -> None:
+    if len(band_names) == dataset.count:
+        for index, name in enumerate(band_names, start=1):
+            dataset.set_band_description(index, name)
+    dataset.update_tags(band_names=",".join(band_names))
+
+
+def compress_geotiff(src_path: Path, dest_path: Path, band_names: list[str] | None = None) -> Path:
     from rasterio.shutil import copy as rio_copy
 
     dest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -81,6 +88,11 @@ def compress_geotiff(src_path: Path, dest_path: Path) -> Path:
         BIGTIFF="YES",
         NUM_THREADS="ALL_CPUS",
     )
+    if band_names is not None:
+        import rasterio
+
+        with rasterio.open(dest_path, "r+") as dst:
+            _write_band_names(dst, band_names)
     return dest_path
 
 
@@ -115,10 +127,7 @@ def stack_geotiffs(
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with rasterio.open(output_path, "w", **profile) as dst:
             dst.write(stacked)
-            if len(band_names) == stacked.shape[0]:
-                for index, name in enumerate(band_names, start=1):
-                    dst.set_band_description(index, name)
-            dst.update_tags(band_names=",".join(band_names))
+            _write_band_names(dst, band_names)
     return output_path
 
 

--- a/deployment/srgan_hpc/run_task.py
+++ b/deployment/srgan_hpc/run_task.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from deployment.srgan_hpc.config import InferenceConfig, ProductConfig
+from deployment.srgan_hpc.inference import run_inference
+from deployment.srgan_hpc.manifests import read_yaml, write_json
+from deployment.srgan_hpc.metadata import write_software_metadata
+from deployment.srgan_hpc.naming import fused_output_name
+from deployment.srgan_hpc.raster import raster_validity_stats, stack_geotiffs
+
+
+LOGGER = logging.getLogger("srgan-hpc")
+
+
+def _resolve_patch_manifest(manifest_path: Path, task_index: int | None) -> dict:
+    manifest = read_yaml(manifest_path)
+    if "tasks" not in manifest:
+        return manifest
+    if task_index is None:
+        raise ValueError("Array task manifest requires task index")
+    task_entries = manifest["tasks"]
+    task = task_entries[task_index]
+    return read_yaml((manifest_path.parent / Path(task["manifest"])).resolve())
+
+
+def _resolve_manifest_local_path(manifest_path: Path, relative_path: str) -> Path:
+    return (manifest_path.parent / relative_path).resolve()
+
+
+def _product_from_dict(data: dict) -> ProductConfig:
+    from deployment.srgan_hpc.config import ModelSourceConfig
+
+    model = data["model"]
+    return ProductConfig(
+        bands=list(data["bands"]),
+        resolution=int(data["resolution"]),
+        factor=int(data["factor"]),
+        model=ModelSourceConfig(
+            preset=model.get("preset"),
+            config_path=model.get("config_path"),
+            checkpoint_path=model.get("checkpoint_path"),
+            cache_dir=model.get("cache_dir"),
+        ),
+    )
+
+
+def _inference_from_dict(data: dict) -> InferenceConfig:
+    return InferenceConfig(
+        window_size=tuple(data["window_size"]),
+        batch_size=data.get("batch_size", 16),
+        overlap=data["overlap"],
+        eliminate_border_px=data["eliminate_border_px"],
+        gpus=data["gpus"],
+        save_preview=data["save_preview"],
+    )
+
+
+def _skip_empty_product(metadata_dir: Path, product_name: str, input_tif: Path, validity: dict[str, int]) -> None:
+    write_json(
+        metadata_dir / f"{product_name}_skip.json",
+        {
+            "status": "skipped",
+            "reason": "empty_input_raster",
+            "product": product_name,
+            "input_tif": str(input_tif),
+            **validity,
+        },
+    )
+
+
+def run_task(manifest_path: Path, task_index: int | None = None) -> Path | None:
+    manifest_path = manifest_path.resolve()
+    root_manifest = read_yaml(manifest_path)
+    if "tasks" in root_manifest:
+        if task_index is None:
+            raise ValueError("Array task manifest requires task index")
+        manifest_path = (manifest_path.parent / Path(root_manifest["tasks"][task_index]["manifest"])).resolve()
+    manifest = _resolve_patch_manifest(manifest_path, None)
+    config = manifest["config"]
+    output_dir = _resolve_manifest_local_path(manifest_path, manifest["paths"]["output_dir"])
+    metadata_dir = _resolve_manifest_local_path(manifest_path, manifest["paths"]["metadata_dir"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    patch_id = str(manifest.get("patch_id", "unknown"))
+    inference = _inference_from_dict(config["inference"])
+
+    outputs: dict[str, str] = {}
+    band_names: list[str] = []
+    LOGGER.info("starting worker task patch_id=%s manifest=%s mode=%s", patch_id, manifest_path, config["mode"])
+
+    for product_name in manifest["products"]:
+        product = _product_from_dict(config[product_name])
+        input_tif = _resolve_manifest_local_path(manifest_path, manifest["paths"]["inputs"][product_name])
+        validity = raster_validity_stats(input_tif)
+        if validity["valid_pixels"] == 0 or validity["nonzero_pixels"] == 0:
+            LOGGER.info("skipping patch_id=%s product=%s because input is empty stats=%s", patch_id, product_name, validity)
+            _skip_empty_product(metadata_dir, product_name, input_tif, validity)
+            write_software_metadata(metadata_dir / "software_env.json")
+            return None
+
+        outputs[product_name] = str(
+            run_inference(
+                input_tif=input_tif,
+                output_dir=output_dir,
+                product_name=product_name,
+                product=product,
+                inference=inference,
+            )
+        )
+        band_names.extend(product.bands)
+
+    final_output: Path
+    if config["mode"] == "fused":
+        final_output = output_dir / fused_output_name()
+        stack_geotiffs(
+            reference_path=Path(outputs["rgbnir"]),
+            secondary_path=Path(outputs["swir"]),
+            output_path=final_output,
+            band_names=band_names,
+        )
+    else:
+        final_output = Path(next(iter(outputs.values())))
+
+    write_json(
+        metadata_dir / "result.json",
+        {
+            "status": "completed",
+            "mode": config["mode"],
+            "outputs": outputs,
+            "final_output": str(final_output),
+            "band_names": band_names,
+        },
+    )
+    write_software_metadata(metadata_dir / "software_env.json")
+    LOGGER.info("completed worker task patch_id=%s output=%s", patch_id, final_output)
+    return final_output

--- a/deployment/srgan_hpc/slurm.py
+++ b/deployment/srgan_hpc/slurm.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from deployment.srgan_hpc.config import EnvironmentConfig, SlurmConfig
+from deployment.srgan_hpc.manifests import write_json
+
+
+@dataclass(slots=True)
+class SlurmJobSpec:
+    job_name: str
+    script_path: Path
+    manifest_path: Path
+    output_path: Path
+    error_path: Path
+    slurm: SlurmConfig
+    environment: EnvironmentConfig
+    array: str | None = None
+
+
+def build_sbatch_command(spec: SlurmJobSpec) -> list[str]:
+    exports = ["ALL", f"SRGAN_HPC_PYTHON={spec.environment.python_executable}"]
+    if spec.environment.modules:
+        exports.append(f"SRGAN_HPC_MODULES={','.join(spec.environment.modules)}")
+    if spec.environment.conda_env:
+        exports.append(f"SRGAN_HPC_CONDA_ENV={spec.environment.conda_env}")
+
+    cmd = [
+        "sbatch",
+        f"--job-name={spec.job_name}",
+        f"--output={spec.output_path}",
+        f"--error={spec.error_path}",
+        f"--export={','.join(exports)}",
+        f"--cpus-per-task={spec.slurm.cpus_per_task}",
+        f"--mem={spec.slurm.mem_gb}G",
+        f"--time={spec.slurm.time}",
+    ]
+    if spec.slurm.partition:
+        cmd.append(f"--partition={spec.slurm.partition}")
+    if spec.slurm.gres:
+        cmd.append(f"--gres={spec.slurm.gres}")
+    elif spec.slurm.gpus:
+        if spec.slurm.gpu_type:
+            cmd.append(f"--gpus={spec.slurm.gpu_type}:{spec.slurm.gpus}")
+        else:
+            cmd.append(f"--gpus={spec.slurm.gpus}")
+    if spec.slurm.account:
+        cmd.append(f"--account={spec.slurm.account}")
+    if spec.slurm.qos:
+        cmd.append(f"--qos={spec.slurm.qos}")
+    if spec.array:
+        cmd.append(f"--array={spec.array}")
+    cmd.extend(spec.slurm.extra_args)
+    cmd.append(str(spec.script_path))
+    cmd.append(str(spec.manifest_path))
+    return cmd
+
+
+def parse_job_id(stdout: str) -> str:
+    parts = stdout.strip().split()
+    if not parts:
+        raise ValueError("Could not parse sbatch output")
+    return parts[-1]
+
+
+def submit_job(spec: SlurmJobSpec, submission_dir: Path, dry_run: bool = False) -> dict[str, str]:
+    cmd = build_sbatch_command(spec)
+    submission_dir.mkdir(parents=True, exist_ok=True)
+    (submission_dir / "sbatch_command.txt").write_text(" ".join(cmd) + "\n", encoding="utf-8")
+
+    if dry_run:
+        payload = {"mode": "dry-run", "command": " ".join(cmd)}
+        write_json(submission_dir / "slurm_job_ids.json", payload)
+        return payload
+
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as exc:
+        payload = {
+            "command": " ".join(cmd),
+            "returncode": str(exc.returncode),
+            "stdout": (exc.stdout or "").strip(),
+            "stderr": (exc.stderr or "").strip(),
+        }
+        write_json(submission_dir / "slurm_job_ids.json", {"mode": "error", **payload})
+        stderr = payload["stderr"] or "<empty stderr>"
+        stdout = payload["stdout"] or "<empty stdout>"
+        raise RuntimeError(
+            "sbatch submission failed. "
+            f"stderr: {stderr}. stdout: {stdout}. "
+            f"Command saved to {submission_dir / 'sbatch_command.txt'}"
+        ) from exc
+
+    job_id = parse_job_id(result.stdout)
+    payload = {"job_id": job_id, "stdout": result.stdout.strip(), "stderr": result.stderr.strip()}
+    write_json(submission_dir / "slurm_job_ids.json", payload)
+    return payload

--- a/deployment/srgan_hpc/slurm/slurm_task_entrypoint.sh
+++ b/deployment/srgan_hpc/slurm/slurm_task_entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MANIFEST_PATH="${1:?manifest path required}"
+PYTHON_BIN="${SRGAN_HPC_PYTHON:-python}"
+
+if [[ -n "${SRGAN_HPC_MODULES:-}" ]] && command -v module >/dev/null 2>&1; then
+  IFS=',' read -r -a MODULE_LIST <<< "${SRGAN_HPC_MODULES}"
+  for module_name in "${MODULE_LIST[@]}"; do
+    module load "${module_name}"
+  done
+fi
+
+if [[ -n "${SRGAN_HPC_CONDA_ENV:-}" ]]; then
+  source activate "${SRGAN_HPC_CONDA_ENV}"
+fi
+
+exec "${PYTHON_BIN}" -m deployment.srgan_hpc.cli run task --manifest "${MANIFEST_PATH}"

--- a/deployment/srgan_hpc/staging.py
+++ b/deployment/srgan_hpc/staging.py
@@ -47,7 +47,7 @@ def ensure_cube_has_valid_data(cube) -> dict[str, int]:
     return stats
 
 
-def is_rate_limit_error(exc: Exception) -> bool:
+def is_retryable_staging_error(exc: Exception) -> bool:
     status_code = getattr(exc, "status_code", None)
     response = getattr(exc, "response", None)
     response_status = getattr(response, "status_code", None)
@@ -55,8 +55,21 @@ def is_rate_limit_error(exc: Exception) -> bool:
         return True
 
     message = str(exc).lower()
-    markers = ["429", "too many requests", "rate limit", "rate-limit"]
+    markers = [
+        "429",
+        "too many requests",
+        "rate limit",
+        "rate-limit",
+        "maximum allowed time",
+        "request timed out",
+        "timeout",
+        "temporarily unavailable",
+    ]
     return any(marker in message for marker in markers)
+
+
+def is_rate_limit_error(exc: Exception) -> bool:
+    return is_retryable_staging_error(exc)
 
 
 def create_cube_with_retry(
@@ -91,12 +104,13 @@ def create_cube_with_retry(
                 resolution=resolution,
             )
         except Exception as exc:  # pragma: no cover
-            if not (config.retry_on_rate_limit and is_rate_limit_error(exc)):
+            if not (config.retry_on_rate_limit and is_retryable_staging_error(exc)):
                 raise
             LOGGER.warning(
-                "Rate limit detected during cubo staging for lat=%s lon=%s. Retrying in %s seconds (%s/%s).",
+                "Retryable cubo staging error for lat=%s lon=%s: %s. Retrying in %s seconds (%s/%s).",
                 latitude,
                 longitude,
+                exc,
                 delay,
                 attempt,
                 len(config.rate_limit_retry_delays_seconds),

--- a/deployment/srgan_hpc/staging.py
+++ b/deployment/srgan_hpc/staging.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+
+import numpy as np
+
+from deployment.srgan_hpc.config import StagingConfig
+from deployment.srgan_hpc.raster import ensure_proj_env, parse_epsg, scale_to_uint16
+
+
+LOGGER = logging.getLogger("srgan-hpc")
+
+
+class SkipTileError(RuntimeError):
+    def __init__(self, reason: str, *, details: dict[str, int] | None = None) -> None:
+        self.reason = reason
+        self.details = details or {}
+        super().__init__(reason)
+
+
+def _cube_validity_stats(cube) -> dict[str, int]:
+    data = np.asarray(cube.data)
+    if data.size == 0:
+        return {"total_pixels": 0, "valid_pixels": 0, "nonzero_pixels": 0}
+
+    total_pixels = int(data.shape[-2] * data.shape[-1])
+    finite_mask = np.isfinite(data)
+    valid_pixels = int(finite_mask.any(axis=0).sum())
+    nonzero_pixels = int((finite_mask & (data != 0)).any(axis=0).sum())
+    return {
+        "total_pixels": total_pixels,
+        "valid_pixels": valid_pixels,
+        "nonzero_pixels": nonzero_pixels,
+    }
+
+
+def ensure_cube_has_valid_data(cube) -> dict[str, int]:
+    stats = _cube_validity_stats(cube)
+    if stats["total_pixels"] == 0:
+        raise SkipTileError("empty_cube", details=stats)
+    if stats["valid_pixels"] == 0:
+        raise SkipTileError("all_nan_cube", details=stats)
+    if stats["nonzero_pixels"] == 0:
+        raise SkipTileError("all_zero_cube", details=stats)
+    return stats
+
+
+def is_rate_limit_error(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    response = getattr(exc, "response", None)
+    response_status = getattr(response, "status_code", None)
+    if status_code == 429 or response_status == 429:
+        return True
+
+    message = str(exc).lower()
+    markers = ["429", "too many requests", "rate limit", "rate-limit"]
+    return any(marker in message for marker in markers)
+
+
+def create_cube_with_retry(
+    *,
+    latitude: float,
+    longitude: float,
+    start_date: str,
+    end_date: str,
+    config: StagingConfig,
+    bands: list[str],
+    edge_size: int,
+    resolution: int,
+):
+    try:
+        import cubo
+        import rioxarray  # noqa: F401
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "srgan-hpc staging requires optional dependencies. Install with `pip install \"opensr-srgan[hpc]\"`."
+        ) from exc
+
+    for attempt, delay in enumerate(config.rate_limit_retry_delays_seconds, start=1):
+        try:
+            return cubo.create(
+                lat=latitude,
+                lon=longitude,
+                collection=config.collection,
+                bands=bands,
+                start_date=start_date,
+                end_date=end_date,
+                edge_size=edge_size,
+                resolution=resolution,
+            )
+        except Exception as exc:  # pragma: no cover
+            if not (config.retry_on_rate_limit and is_rate_limit_error(exc)):
+                raise
+            LOGGER.warning(
+                "Rate limit detected during cubo staging for lat=%s lon=%s. Retrying in %s seconds (%s/%s).",
+                latitude,
+                longitude,
+                delay,
+                attempt,
+                len(config.rate_limit_retry_delays_seconds),
+            )
+            time.sleep(delay)
+
+    return cubo.create(
+        lat=latitude,
+        lon=longitude,
+        collection=config.collection,
+        bands=bands,
+        start_date=start_date,
+        end_date=end_date,
+        edge_size=edge_size,
+        resolution=resolution,
+    )
+
+
+def stage_cutout(
+    *,
+    latitude: float,
+    longitude: float,
+    start_date: str,
+    end_date: str,
+    config: StagingConfig,
+    bands: list[str],
+    edge_size: int,
+    resolution: int,
+    output_path: Path,
+) -> Path:
+    ensure_proj_env()
+    LOGGER.info(
+        "staging cubo cutout lat=%s lon=%s start_date=%s end_date=%s output=%s",
+        latitude,
+        longitude,
+        start_date,
+        end_date,
+        output_path,
+    )
+    cube = create_cube_with_retry(
+        latitude=latitude,
+        longitude=longitude,
+        start_date=start_date,
+        end_date=end_date,
+        config=config,
+        bands=bands,
+        edge_size=edge_size,
+        resolution=resolution,
+    )
+    if "time" in cube.dims:
+        cube = cube.isel(time=config.image_index)
+    cube = cube.transpose("band", "y", "x")
+    stats = ensure_cube_has_valid_data(cube)
+    LOGGER.info("validated staged cutout lat=%s lon=%s stats=%s", latitude, longitude, stats)
+
+    epsg_text = str(cube.attrs.get("epsg", "") or cube.coords.get("epsg", ""))
+    epsg_code = parse_epsg(epsg_text, latitude, longitude)
+    cube = cube.rio.write_crs(epsg_code, inplace=False)
+
+    if config.output_dtype == "uint16":
+        cube = cube.copy(data=scale_to_uint16(cube.data))
+    cube = cube.rio.write_nodata(config.nodata, encoded=True, inplace=False)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cube.rio.to_raster(
+        output_path,
+        compress=config.compression,
+        tiled=True,
+        blockxsize=512,
+        blockysize=512,
+        BIGTIFF="YES",
+    )
+    LOGGER.info("wrote staged cutout lat=%s lon=%s output=%s", latitude, longitude, output_path)
+    return output_path.resolve()

--- a/deployment/srgan_hpc/submit.py
+++ b/deployment/srgan_hpc/submit.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+from deployment.srgan_hpc.config import (
+    RuntimeConfig,
+    enabled_product_names,
+    get_product_config,
+    product_edge_size,
+    runtime_config_to_dict,
+)
+from deployment.srgan_hpc.manifests import new_run_id, write_json, write_yaml
+from deployment.srgan_hpc.naming import patch_dir, resolve_run_dir
+from deployment.srgan_hpc.patching import Patch
+from deployment.srgan_hpc.slurm import SlurmJobSpec, submit_job
+from deployment.srgan_hpc.staging import SkipTileError, stage_cutout
+
+
+def _patch_manifest(
+    *,
+    patch: Patch,
+    run_id: str,
+    start_date: str,
+    end_date: str,
+    config: RuntimeConfig,
+    ) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "patch_id": patch.patch_id,
+        "patch_index": patch.row_index * patch.column_count + patch.column_index,
+        "latitude": patch.latitude,
+        "longitude": patch.longitude,
+        "edge_size": patch.edge_size,
+        "start_date": start_date,
+        "end_date": end_date,
+        "products": enabled_product_names(config),
+        "paths": {
+            "run_dir": "../..",
+            "inputs": {product: f"inputs/{product}.tif" for product in enabled_product_names(config)},
+            "output_dir": "outputs",
+            "metadata_dir": "metadata",
+        },
+        "config": runtime_config_to_dict(config),
+    }
+
+
+def _write_skip_metadata(
+    *,
+    patch_root: Path,
+    patch: Patch,
+    reason: str,
+    details: dict[str, int],
+    start_date: str,
+    end_date: str,
+) -> None:
+    metadata_dir = patch_root / "metadata"
+    metadata_dir.mkdir(parents=True, exist_ok=True)
+    write_json(
+        metadata_dir / "skip.json",
+        {
+            "status": "skipped",
+            "reason": reason,
+            "details": details,
+            "patch_id": patch.patch_id,
+            "latitude": patch.latitude,
+            "longitude": patch.longitude,
+            "start_date": start_date,
+            "end_date": end_date,
+        },
+    )
+
+
+def _stage_patch_inputs(
+    *,
+    patch: Patch,
+    start_date: str,
+    end_date: str,
+    config: RuntimeConfig,
+    patch_root: Path,
+    dry_run: bool,
+) -> None:
+    for product_name in enabled_product_names(config):
+        product = get_product_config(config, product_name)
+        input_tif = patch_root / "inputs" / f"{product_name}.tif"
+        if dry_run:
+            input_tif.parent.mkdir(parents=True, exist_ok=True)
+            continue
+        stage_cutout(
+            latitude=patch.latitude,
+            longitude=patch.longitude,
+            start_date=start_date,
+            end_date=end_date,
+            config=config.staging,
+            bands=product.bands,
+            edge_size=product_edge_size(config, product),
+            resolution=product.resolution,
+            output_path=input_tif,
+        )
+
+
+def submit_patch_run(
+    *,
+    config: RuntimeConfig,
+    patch: Patch,
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    dry_run: bool = False,
+) -> tuple[str, Path, Mapping[str, object]]:
+    run_id = new_run_id(config.project_name)
+    run_dir = resolve_run_dir(config.output_root, run_id)
+    logs_dir = run_dir / "logs"
+    patch_root = patch_dir(run_dir, patch.patch_id)
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    write_yaml(run_dir / "resolved_config.yaml", runtime_config_to_dict(config))
+
+    if not dry_run:
+        try:
+            _stage_patch_inputs(
+                patch=patch,
+                start_date=start_date,
+                end_date=end_date,
+                config=config,
+                patch_root=patch_root,
+                dry_run=False,
+            )
+        except SkipTileError as exc:
+            manifest = _patch_manifest(
+                patch=patch,
+                run_id=run_id,
+                start_date=start_date,
+                end_date=end_date,
+                config=config,
+            )
+            manifest["status"] = "skipped"
+            manifest["skip_reason"] = exc.reason
+            manifest["skip_details"] = exc.details
+            manifest_path = patch_root / "manifest.yaml"
+            write_yaml(manifest_path, manifest)
+            _write_skip_metadata(
+                patch_root=patch_root,
+                patch=patch,
+                reason=exc.reason,
+                details=exc.details,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            write_yaml(
+                run_dir / "run_manifest.yaml",
+                {
+                    "run_id": run_id,
+                    "mode": "patch",
+                    "patch_count": 1,
+                    "tasks": [],
+                    "skipped": [{"patch_id": patch.patch_id, "reason": exc.reason}],
+                },
+            )
+            return run_id, run_dir, {"mode": "skipped", "reason": exc.reason, **exc.details}
+    else:
+        _stage_patch_inputs(
+            patch=patch,
+            start_date=start_date,
+            end_date=end_date,
+            config=config,
+            patch_root=patch_root,
+            dry_run=True,
+        )
+
+    manifest = _patch_manifest(
+        patch=patch,
+        run_id=run_id,
+        start_date=start_date,
+        end_date=end_date,
+        config=config,
+    )
+    write_yaml(
+        run_dir / "run_manifest.yaml",
+        {
+            "run_id": run_id,
+            "mode": "patch",
+            "patch_count": 1,
+            "tasks": [{"patch_id": patch.patch_id, "manifest": f"patches/{patch.patch_id}/manifest.yaml"}],
+        },
+    )
+    manifest_path = patch_root / "manifest.yaml"
+    write_yaml(manifest_path, manifest)
+
+    spec = SlurmJobSpec(
+        job_name=f"srgan_{patch.patch_id}",
+        script_path=script_path,
+        manifest_path=manifest_path,
+        output_path=logs_dir / f"slurm_{patch.patch_id}.out",
+        error_path=logs_dir / f"slurm_{patch.patch_id}.err",
+        slurm=config.slurm,
+        environment=config.environment,
+    )
+    submission = submit_job(spec, run_dir / "submission", dry_run=dry_run)
+    return run_id, run_dir, submission
+
+
+def _submit_patch_collection(
+    *,
+    mode: str,
+    config: RuntimeConfig,
+    patches: list[Patch],
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    dry_run: bool = False,
+    aoi_path: Path | None = None,
+    aoi_layer: str | None = None,
+) -> tuple[str, Path, Mapping[str, object]]:
+    run_id = new_run_id(config.project_name)
+    run_dir = resolve_run_dir(config.output_root, run_id)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = run_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    write_yaml(run_dir / "resolved_config.yaml", runtime_config_to_dict(config))
+
+    tasks: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    for patch_index, patch in enumerate(patches):
+        patch_root = patch_dir(run_dir, patch.patch_id)
+        if not dry_run:
+            try:
+                _stage_patch_inputs(
+                    patch=patch,
+                    start_date=start_date,
+                    end_date=end_date,
+                    config=config,
+                    patch_root=patch_root,
+                    dry_run=False,
+                )
+            except SkipTileError as exc:
+                manifest = _patch_manifest(
+                    patch=patch,
+                    run_id=run_id,
+                    start_date=start_date,
+                    end_date=end_date,
+                    config=config,
+                )
+                manifest["patch_index"] = patch_index
+                manifest["status"] = "skipped"
+                manifest["skip_reason"] = exc.reason
+                manifest["skip_details"] = exc.details
+                write_yaml(patch_root / "manifest.yaml", manifest)
+                _write_skip_metadata(
+                    patch_root=patch_root,
+                    patch=patch,
+                    reason=exc.reason,
+                    details=exc.details,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+                skipped.append({"patch_id": patch.patch_id, "reason": exc.reason, **exc.details})
+                continue
+        else:
+            _stage_patch_inputs(
+                patch=patch,
+                start_date=start_date,
+                end_date=end_date,
+                config=config,
+                patch_root=patch_root,
+                dry_run=True,
+            )
+
+        manifest = _patch_manifest(
+            patch=patch,
+            run_id=run_id,
+            start_date=start_date,
+            end_date=end_date,
+            config=config,
+        )
+        manifest["patch_index"] = patch_index
+        write_yaml(patch_root / "manifest.yaml", manifest)
+        tasks.append(manifest)
+
+    run_manifest = {
+        "run_id": run_id,
+        "mode": mode,
+        "patch_count": len(tasks),
+        "start_date": start_date,
+        "end_date": end_date,
+        "skipped_count": len(skipped),
+        "tasks": [
+            {"patch_id": str(task["patch_id"]), "manifest": f"patches/{task['patch_id']}/manifest.yaml"}
+            for task in tasks
+        ],
+        "skipped": skipped,
+    }
+    if aoi_path is not None:
+        run_manifest["aoi_path"] = str(aoi_path)
+    if aoi_layer is not None:
+        run_manifest["aoi_layer"] = aoi_layer
+    write_yaml(run_dir / "run_manifest.yaml", run_manifest)
+
+    if not tasks:
+        return run_id, run_dir, {"mode": "skipped", "reason": "no_submittable_patches", "skipped": len(skipped)}
+
+    spec = SlurmJobSpec(
+        job_name=f"srgan_{run_id}",
+        script_path=script_path,
+        manifest_path=run_dir / "run_manifest.yaml",
+        output_path=logs_dir / "slurm_%A_%a.out",
+        error_path=logs_dir / "slurm_%A_%a.err",
+        slurm=config.slurm,
+        environment=config.environment,
+        array=f"0-{len(tasks) - 1}" if tasks else None,
+    )
+    submission = submit_job(spec, run_dir / "submission", dry_run=dry_run)
+    return run_id, run_dir, submission
+
+
+def submit_grid_run(
+    *,
+    config: RuntimeConfig,
+    patches: list[Patch],
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    dry_run: bool = False,
+) -> tuple[str, Path, Mapping[str, object]]:
+    return _submit_patch_collection(
+        mode="grid",
+        config=config,
+        patches=patches,
+        start_date=start_date,
+        end_date=end_date,
+        script_path=script_path,
+        dry_run=dry_run,
+    )
+
+
+def submit_aoi_run(
+    *,
+    config: RuntimeConfig,
+    patches: list[Patch],
+    start_date: str,
+    end_date: str,
+    script_path: Path,
+    aoi_path: Path,
+    aoi_layer: str | None = None,
+    dry_run: bool = False,
+) -> tuple[str, Path, Mapping[str, object]]:
+    return _submit_patch_collection(
+        mode="aoi",
+        config=config,
+        patches=patches,
+        start_date=start_date,
+        end_date=end_date,
+        script_path=script_path,
+        dry_run=dry_run,
+        aoi_path=aoi_path,
+        aoi_layer=aoi_layer,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,14 +45,30 @@ package-dir = {"" = "."}
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["opensr_srgan", "opensr_srgan.*"]
+include = ["opensr_srgan", "opensr_srgan.*", "deployment", "deployment.*"]
 
 [tool.setuptools.package-data]
 opensr_srgan = [
   "configs/*.yaml",
   "configs/**/*.yaml",
 ]
+deployment = [
+  "configs/*.yaml",
+  "srgan_hpc/slurm/*.sh",
+]
 
 [project.optional-dependencies]
 tests = ["pytest", "pytest-cov","numpy"]
 docs = ["mkdocs-material"]
+hpc = [
+  "PyYAML>=6.0",
+  "pyproj>=3.4",
+  "pyshp>=2.3.1",
+  "rioxarray>=0.15",
+  "shapely>=2.0.2",
+  "cubo>=0.3",
+  "opensr-utils>=1.0.0",
+]
+
+[project.scripts]
+srgan-hpc = "deployment.srgan_hpc.cli:main"

--- a/tests/test_deployment_aoi.py
+++ b/tests/test_deployment_aoi.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deployment.srgan_hpc.aoi import resolve_aoi_source_path
+
+
+def test_resolve_aoi_source_accepts_direct_shapefile(tmp_path: Path) -> None:
+    shp_path = tmp_path / "area.shp"
+    shp_path.touch()
+
+    assert resolve_aoi_source_path(shp_path) == shp_path.resolve()
+
+
+def test_resolve_aoi_source_accepts_directory_with_one_shapefile(tmp_path: Path) -> None:
+    shp_path = tmp_path / "area.shp"
+    shp_path.touch()
+
+    assert resolve_aoi_source_path(tmp_path) == shp_path.resolve()
+
+
+def test_resolve_aoi_source_rejects_directory_with_multiple_shapefiles(tmp_path: Path) -> None:
+    (tmp_path / "a.shp").touch()
+    (tmp_path / "b.shp").touch()
+
+    with pytest.raises(ValueError, match="exactly one"):
+        resolve_aoi_source_path(tmp_path)

--- a/tests/test_deployment_collect.py
+++ b/tests/test_deployment_collect.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from deployment.srgan_hpc.collect import collect_outputs
+
+
+def test_collect_outputs_preserves_patch_identity_for_duplicate_product_names(tmp_path: Path) -> None:
+    run_dir = tmp_path / "run"
+    for patch_id, marker in (("patch_000001", b"first"), ("patch_000002", b"second")):
+        output_dir = run_dir / "patches" / patch_id / "outputs"
+        output_dir.mkdir(parents=True)
+        (output_dir / "fused_sr.tif").write_bytes(marker)
+
+    destination, copied = collect_outputs(run_dir)
+
+    assert destination == run_dir / "collected"
+    assert copied == 2
+    assert (destination / "patch_000001" / "fused_sr.tif").read_bytes() == b"first"
+    assert (destination / "patch_000002" / "fused_sr.tif").read_bytes() == b"second"

--- a/tests/test_deployment_config.py
+++ b/tests/test_deployment_config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deployment.srgan_hpc.config import (
+    RuntimeConfig,
+    enabled_product_names,
+    load_runtime_config,
+    patch_resolution,
+    product_edge_size,
+)
+
+
+def test_default_config_enables_fused_products() -> None:
+    config = load_runtime_config(Path("deployment/configs/runtime.default.yaml"))
+
+    assert config.mode == "fused"
+    assert enabled_product_names(config) == ["rgbnir", "swir"]
+    assert patch_resolution(config) == 10
+    assert product_edge_size(config, config.rgbnir) == 4096
+    assert product_edge_size(config, config.swir) == 2048
+
+
+def test_single_product_modes_select_expected_products() -> None:
+    rgbnir = RuntimeConfig(mode="rgbnir")
+    swir = RuntimeConfig(mode="swir")
+
+    assert enabled_product_names(rgbnir) == ["rgbnir"]
+    assert enabled_product_names(swir) == ["swir"]
+    assert patch_resolution(swir) == 20
+
+
+def test_invalid_mode_is_rejected(tmp_path: Path) -> None:
+    config_path = tmp_path / "runtime.yaml"
+    config_path.write_text("mode: bad\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mode must be one of"):
+        load_runtime_config(config_path)

--- a/tests/test_deployment_raster.py
+++ b/tests/test_deployment_raster.py
@@ -6,7 +6,7 @@ import numpy as np
 import rasterio
 from rasterio.transform import from_origin
 
-from deployment.srgan_hpc.raster import stack_geotiffs
+from deployment.srgan_hpc.raster import compress_geotiff, stack_geotiffs
 
 
 def _write_tif(path: Path, data: np.ndarray, transform) -> None:
@@ -48,3 +48,15 @@ def test_stack_geotiffs_reprojects_to_reference_grid_and_writes_band_names(tmp_p
         assert src.height == 8
         assert src.transform == from_origin(500000, 5100000, 2.5, 2.5)
         assert src.descriptions == ("B04", "B03", "B02", "B08", "B05", "B06", "B07", "B8A", "B11", "B12")
+
+
+def test_compress_geotiff_writes_band_names(tmp_path: Path) -> None:
+    source = tmp_path / "source.tif"
+    output = tmp_path / "rgbnir_sr.tif"
+    _write_tif(source, np.ones((4, 8, 8), dtype="uint16"), from_origin(500000, 5100000, 2.5, 2.5))
+
+    compress_geotiff(source, output, band_names=["B04", "B03", "B02", "B08"])
+
+    with rasterio.open(output) as src:
+        assert src.descriptions == ("B04", "B03", "B02", "B08")
+        assert src.tags()["band_names"] == "B04,B03,B02,B08"

--- a/tests/test_deployment_raster.py
+++ b/tests/test_deployment_raster.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+
+from deployment.srgan_hpc.raster import stack_geotiffs
+
+
+def _write_tif(path: Path, data: np.ndarray, transform) -> None:
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        width=data.shape[-1],
+        height=data.shape[-2],
+        count=data.shape[0],
+        dtype=data.dtype,
+        crs="EPSG:32632",
+        transform=transform,
+        nodata=0,
+    ) as dst:
+        dst.write(data)
+
+
+def test_stack_geotiffs_reprojects_to_reference_grid_and_writes_band_names(tmp_path: Path) -> None:
+    reference = tmp_path / "rgbnir.tif"
+    secondary = tmp_path / "swir.tif"
+    output = tmp_path / "fused.tif"
+    ref_data = np.ones((4, 8, 8), dtype="uint16")
+    secondary_data = np.full((6, 4, 4), 2, dtype="uint16")
+
+    _write_tif(reference, ref_data, from_origin(500000, 5100000, 2.5, 2.5))
+    _write_tif(secondary, secondary_data, from_origin(500000, 5100000, 5.0, 5.0))
+
+    stack_geotiffs(
+        reference_path=reference,
+        secondary_path=secondary,
+        output_path=output,
+        band_names=["B04", "B03", "B02", "B08", "B05", "B06", "B07", "B8A", "B11", "B12"],
+    )
+
+    with rasterio.open(output) as src:
+        assert src.count == 10
+        assert src.width == 8
+        assert src.height == 8
+        assert src.transform == from_origin(500000, 5100000, 2.5, 2.5)
+        assert src.descriptions == ("B04", "B03", "B02", "B08", "B05", "B06", "B07", "B8A", "B11", "B12")

--- a/tests/test_deployment_staging.py
+++ b/tests/test_deployment_staging.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from deployment.srgan_hpc.staging import is_retryable_staging_error
+
+
+class ResponseError(Exception):
+    def __init__(self, status_code: int) -> None:
+        self.response = type("Response", (), {"status_code": status_code})()
+        super().__init__(f"HTTP {status_code}")
+
+
+def test_retryable_staging_error_detects_rate_limit_status() -> None:
+    assert is_retryable_staging_error(ResponseError(429))
+
+
+def test_retryable_staging_error_detects_planetary_computer_timeout() -> None:
+    error = RuntimeError("The request exceeded the maximum allowed time, please try again.")
+
+    assert is_retryable_staging_error(error)
+
+
+def test_retryable_staging_error_rejects_unrelated_errors() -> None:
+    assert not is_retryable_staging_error(RuntimeError("invalid asset href"))

--- a/tests/test_deployment_submit.py
+++ b/tests/test_deployment_submit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from deployment.srgan_hpc.config import RuntimeConfig
+from deployment.srgan_hpc.manifests import read_yaml
+from deployment.srgan_hpc.patching import Patch
+from deployment.srgan_hpc.submit import submit_patch_run
+
+
+def test_submit_patch_dry_run_writes_product_inputs_and_manifest(tmp_path: Path) -> None:
+    config = RuntimeConfig(output_root=tmp_path / "runs", mode="fused")
+    patch = Patch(
+        patch_id="patch_000001",
+        latitude=45.0,
+        longitude=9.0,
+        edge_size=512,
+        row_index=0,
+        row_count=1,
+        column_index=0,
+        column_count=1,
+    )
+
+    _, run_dir, submission = submit_patch_run(
+        config=config,
+        patch=patch,
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        script_path=Path("/tmp/slurm.sh"),
+        dry_run=True,
+    )
+
+    manifest_path = run_dir / "patches" / "patch_000001" / "manifest.yaml"
+    manifest = read_yaml(manifest_path)
+    assert manifest["products"] == ["rgbnir", "swir"]
+    assert manifest["paths"]["inputs"] == {
+        "rgbnir": "inputs/rgbnir.tif",
+        "swir": "inputs/swir.tif",
+    }
+    assert (run_dir / "patches" / "patch_000001" / "inputs").is_dir()
+    assert submission["mode"] == "dry-run"


### PR DESCRIPTION
## Summary
   This PR adds a Slurm-based HPC deployment launcher for running SRGAN inference over Sentinel-2 cutouts.
  Solves #110 
  The new srgan-hpc CLI supports:

  - config validation
  - single patch submission
  - bounding-box grid submission
  - AOI shapefile submission
  - worker task execution
  - output collection
  - run status inspection

  It supports three SRGAN runtime modes:

  - rgbnir: runs the RGB-NIR preset on B04/B03/B02/B08
  - swir: runs the SWIR preset on B05/B06/B07/B8A/B11/B12
  - fused: runs both and writes a 10-band fused GeoTIFF

  ## Main Changes

  HPC Launcher and CLI

  - Added the installable deployment.srgan_hpc package.
  - Added srgan-hpc console entrypoint.
  - Added Slurm submission helpers and worker entrypoint script.
  - Added commands for validate-config, submit patch, submit grid, submit aoi, run task, collect, and status.

  AOI and Patch Management

  - Added AOI shapefile support.
  - AOI input accepts either a .shp file or a directory containing exactly one .shp.
  - Added CRS validation/reprojection for AOIs.
  - Added grid/patch selection utilities with overlap support.

  SRGAN Runtime Configuration

  - Added default, test, and A100 example runtime configs.
  - Added separate RGB-NIR and SWIR product configuration blocks.
  - Added support for Hugging Face presets or local config/checkpoint paths.
  - Added runtime mode selection via mode: rgbnir | swir | fused.

  Inference and Output Handling

  - Added SRGAN inference wrapper using opensr_srgan and opensr-utils.
  - Added fused GeoTIFF creation by aligning SWIR output to the RGB-NIR SR grid.
  - Added deterministic fused band order:
    B04, B03, B02, B08, B05, B06, B07, B8A, B11, B12.
  - Added metadata writing, output collection, and run status helpers.

  Packaging

  - Included deployment packages in setuptools discovery.
  - Added hpc optional dependencies.
  - Added package data for deployment configs and Slurm scripts.

  ## How Has This Been Tested?

  - [X] Deployment config tests

  python -m pytest tests/test_deployment_config.py -q

  - [X] Dry-run submission tests

  python -m pytest tests/test_deployment_submit.py -q

  - [X] AOI shapefile path handling tests

  python -m pytest tests/test_deployment_aoi.py -q

  - [X] Fused raster stacking tests

  python -m pytest tests/test_deployment_raster.py -q

  - [X] Full deployment test subset

  python -m pytest \
    tests/test_deployment_config.py \
    tests/test_deployment_submit.py \
    tests/test_deployment_raster.py \
    tests/test_deployment_aoi.py \
    -q

  Result:

  8 passed

  - [X] CLI config validation smoke test

  python -m deployment.srgan_hpc.cli validate-config \
    --config deployment/configs/runtime.default.yaml

  ## Checklist

  - [X] I have performed a self-review of my own code
  - [X] I have commented my code, particularly in hard-to-understand areas
  - [X] I have made corresponding changes to the documentation
  - [X] My changes generate no new warnings
  - [X] I have added tests that prove that my feature works
  - [X] New and existing unit tests pass locally with my changes
  - [X] Any dependent changes have been merged and published in downstream modules